### PR TITLE
Manifest files with quoted cell values not getting submitted fix

### DIFF
--- a/app.R
+++ b/app.R
@@ -552,7 +552,7 @@ schema_to_display_lookup <- data.frame(schema_name, display_name)
       ### make into a csv or table for assay components
       ### already has entityId
       if ("entityId" %in% colnames(infile)) {
-        write.csv(infile, file = "./files/synapse_storage_manifest.csv", quote = FALSE, row.names = FALSE, na = "")
+        write.csv(infile, file = "./files/synapse_storage_manifest.csv", quote = TRUE, row.names = FALSE, na = "")
 
       } else {
         # if not get ids
@@ -578,7 +578,7 @@ schema_to_display_lookup <- data.frame(schema_name, display_name)
         colnames(files_df) <- c("entityId", "Filename")
         files_entity <- inner_join(infile, files_df, by = "Filename")
 
-        write.csv(files_entity, file = "./files/synapse_storage_manifest.csv", quote = FALSE, row.names = FALSE, na = "")
+        write.csv(files_entity, file = "./files/synapse_storage_manifest.csv", quote = TRUE, row.names = FALSE, na = "")
       }
       selected_project <- input$var
       selected_folder <- input$dataset
@@ -632,7 +632,7 @@ schema_to_display_lookup <- data.frame(schema_name, display_name)
       }
 
     } else {
-      write.csv(infile, file = "./files/synapse_storage_manifest.csv", quote = FALSE, row.names = FALSE, na = "")
+      write.csv(infile, file = "./files/synapse_storage_manifest.csv", quote = TRUE, row.names = FALSE, na = "")
 
       selected_project <- input$var
       selected_folder <- input$dataset


### PR DESCRIPTION
Exporting CSV files from MS Excel does not add quotation marks around all elements. It inserts quotations around only those elements with a separator like ",". So by setting the `quote` option for `write.csv()` to `TRUE` we are essentially creating "quoted style" CSV files.