### PR TITLE
add alphabetical sort for storage projects

### DIFF
--- a/app.R
+++ b/app.R
@@ -222,7 +222,7 @@ server <- function(input, output, session) {
       }
 
       ### updates project dropdown
-      updateSelectizeInput(session, 'var', choices = names(projects_namedList))
+      updateSelectizeInput(session, 'var', choices = sort(names(projects_namedList)))
 
       ### update waiter loading screen once login successful
       waiter_update(


### PR DESCRIPTION
We have many investigators with multiple projects. It's helpful to have an alphabetical sort to the dropdown to provide some sort of easy-to-interpret order. We've made this change in the NF curator app but thought it might be more broadly useful. (and it's just a simple change :) )