### PR TITLE
better errorhandling for mismatched template

### DIFF
--- a/app.R
+++ b/app.R
@@ -446,45 +446,66 @@ schema_to_display_lookup <- data.frame(schema_name, display_name)
 
 
     if (length(annotation_status) != 0) {
-
       ## if error not empty aka there is an error
-      filled_manifest <- metadata_model$populateModelManifest(paste0(config$community," ", input$template_type), input$file1$datapath, template_type)
-
       ### create list of string names for the error messages if there is more than one at a time 
       str_names <- c()
-
+      
       ### initialize list of errors and column names to highlight 
       error_values <- c()
       column_names <- c()
-
-      ### loop through the multiple error messages
-      for (i in seq_along(annotation_status)) {
+      
+      # mismatched template index
+      inx_mt <- which(sapply(annotation_status, function(x) grepl("Component value provided is: .*, whereas the Template Type is: .*", x[[3]])))
+      
+      if (length(inx_mt) > 0) {  # mismatched error(s): selected template mismatched with validating template
         
+        # get all mismatched components
+        error_values <- sapply(annotation_status[inx_mt], function(x) x[[4]][[1]]) %>% unique()
+        column_names <- "Component"
+        
+        # error messages for mismatch
+        mismatch_c <- error_values %>% sQuote %>% paste(collapse = ", ")
+        str_names <- paste0("The submitted metadata contains << <b>", mismatch_c, "</b> >> in the Component column, but requested validation for << <b>",  input$template_type, "</b> >>.")
+        help_msg <- paste0("Please check that you have selected the correct template in the <b>Select your Dataset</b> tab and 
+                            ensure your metadata contains <b>only</b> one template, e.g. ", input$template_type, ".")
 
-        row <- annotation_status[i][[1]][1]
-        column <- annotation_status[i][[1]][2]
-        message <- annotation_status[i][[1]][3]
-
-        error_value <- annotation_status[i][[1]][4]
-
-        ## if empty value change to NA ### not reporting the value in the cell anymore!!!
-        if (unlist(error_value) == "") {
-          error_value <- NA
+      } else {
+        
+        filled_manifest <- metadata_model$populateModelManifest(paste0(config$community," ", input$template_type), input$file1$datapath, template_type)
+  
+        ### loop through the multiple error messages
+        for (i in seq_along(annotation_status)) {
           
-        } else {
-
-          error_value <- error_value
+  
+          row <- annotation_status[i][[1]][1]
+          column <- annotation_status[i][[1]][2]
+          message <- annotation_status[i][[1]][3]
+  
+          error_value <- annotation_status[i][[1]][4]
+  
+          ## if empty value change to NA ### not reporting the value in the cell anymore!!!
+          if (unlist(error_value) == "") {
+            error_value <- NA
+            
+          } else {
+  
+            error_value <- error_value
+          }
+  
+          
+          error_values[i] <- error_value
+          column_names[i] <- column
+          str_names[i] <- paste( paste0(i, "."),
+                                "At row <b>", row, 
+                                "</b>value <b>", error_value,
+                                "</b>in ", "<b>", column, "</b>",
+                                message, paste0("</b>", "<br/>"), sep = " ")
         }
-
         
-        error_values[i] <- error_value
-        column_names[i] <- column
-        str_names[i] <- paste( paste0(i, "."),
-                              "At row <b>", row, 
-                              "</b>value <b>", error_value,
-                              "</b>in ", "<b>", column, "</b>",
-                              message, paste0("</b>", "<br/>"), sep = " ")
+        help_msg <- paste0("Please edit your data locally or ", '<a target="_blank" href="', filled_manifest, '">on Google Sheets </a>')
+        
       }
+    
  
       validate_w$update(
         html = h3(sprintf("%d errors found", length(annotation_status)))
@@ -494,12 +515,9 @@ schema_to_display_lookup <- data.frame(schema_name, display_name)
       ### format output text
       output$text2 <- renderUI({
           tagList( 
-          HTML("Your metadata is invalid according to the data model.<br/> ",
-              "You have", length(annotation_status), " errors: <br/>"),
+          HTML("Your metadata is invalid according to the data model. The submitted metadata have <b>", length(annotation_status), "</b> errors.<br/><br/>"),
           HTML(str_names),
-          HTML("<br/>Edit your data locally or ",
-              paste0('<a target="_blank" href="', filled_manifest, '">on Google Sheets </a>')
-              )
+          HTML("<br/><br/>", help_msg)
 
           )
       })


### PR DESCRIPTION
This PR is trying to fix #61 

When user selects the metadata template X, but metadata contains template Y(s).

If any mismatch error exists, users will only see the error messages: 

> Your metadata is invalid according to the data model. The submitted metadata have **number** errors.<br/><br/> The submitted metadata contains <<**template Y(s)** >> in the Component column, but requested validation for << **template X**>>.<br/><br/> Please check that you have selected the correct template in the <b>Select your Dataset</b> tab and ensure your metadata contains <b>only</b> one template, e.g. template X.

In addition, the google spreadsheet will not be created for the mismatched error, which can shorten validation process time a bit. 

Please feel free to have any feedbacks and advice. 

Thank you. 