### PR TITLE
be able to clear/hide previous content when user select new template …

### DIFF
--- a/app.R
+++ b/app.R
@@ -387,7 +387,6 @@ schema_to_display_lookup <- data.frame(schema_name, display_name)
       manifest_entity <- syn_get(existing_manifestID)
       # prepopulatedManifestURL = mm.populateModelManifest("test_update", entity.path, component)
       manifest_url <- metadata_model$populateModelManifest(paste0(config$community," ", input$template_type), manifest_entity$path, template_type)
-      # toggle('text_div3') # no text_div3 in ui
 
       output$text <- renderUI({
         tags$a(href = manifest_url, manifest_url, target = "_blank")

--- a/app.R
+++ b/app.R
@@ -318,6 +318,12 @@ output$manifest_display_name <- renderUI({
 
 })
 
+observeEvent({input$dataset
+              input$template_type
+              }, {
+                sapply(c('text_div', 'text_div2', 'tbl2', 'gsheet_btn', 'gsheet_div', 'submitButton'), FUN=hide)
+})
+
 schema_to_display_lookup <- data.frame(schema_name, display_name)
 
   # loading screen for template link generation
@@ -370,7 +376,7 @@ schema_to_display_lookup <- data.frame(schema_name, display_name)
 
 
       ## links shows in text box
-      toggle('text_div')
+      show('text_div')
       ### if want a progress bar need more feedback from API to know how to increment progress bar ###
 
       output$text <- renderUI({
@@ -381,7 +387,7 @@ schema_to_display_lookup <- data.frame(schema_name, display_name)
       manifest_entity <- syn_get(existing_manifestID)
       # prepopulatedManifestURL = mm.populateModelManifest("test_update", entity.path, component)
       manifest_url <- metadata_model$populateModelManifest(paste0(config$community," ", input$template_type), manifest_entity$path, template_type)
-      toggle('text_div3')
+      # toggle('text_div3') # no text_div3 in ui
 
       output$text <- renderUI({
         tags$a(href = manifest_url, manifest_url, target = "_blank")
@@ -407,7 +413,11 @@ schema_to_display_lookup <- data.frame(schema_name, display_name)
     infile <- infile[, !grepl('^X', colnames(infile))]
     infile <- infile[rowSums(is.na(infile)) != ncol(infile), ]
   })
-
+  
+  observeEvent(input$file1, {
+    sapply(c('text_div2', 'tbl2', 'gsheet_btn', 'gsheet_div', 'submitButton'), FUN=hide)
+  })
+  
   ### renders in DT for preview 
   observeEvent(
   rawData(), {


### PR DESCRIPTION
Update based on PR #122, in order to be able to clear/hide previous content when user select new template.

Two scenarios:

When users select new template in the "Select your Dataset", hide

- **(previous) gsheet link** in the "Get Metadata Template"
- **All (previous) validation results** in the "Submit & Validate Metadata": **error messages, gsheet button/gsheet link**

When user re-upload the .csv in the "Submit & Validate Metadata", hide

- All (previous) validation results in the "Submit & Validate Metadata": error messages, gsheet button/gsheet link