### PR TITLE
Add new parameters to support use_annotations

### DIFF
--- a/app.R
+++ b/app.R
@@ -385,7 +385,7 @@ schema_to_display_lookup <- data.frame(schema_name, display_name)
 						      datasetId = folder_synID,
 						      filenames = as.list(filename_list),
 						      useAnnotations = F,
-						      sheetUrl = F)
+						      sheetUrl = T)
       ### make sure not scalar if length of list is 1 in R
       ## add in the step to convert names later ###
 

--- a/app.R
+++ b/app.R
@@ -379,7 +379,13 @@ schema_to_display_lookup <- data.frame(schema_name, display_name)
       filename_list <- names(file_namedList)
 
 
-      manifest_url <- metadata_model$getModelManifest(paste0(config$community," ", input$template_type), template_type, filenames = as.list(filename_list))
+      manifest_url <- metadata_model$getModelManifest(paste0(config$community," ", input$template_type), 
+						      template_type, 
+						      filenames = as.list(filename_list),
+						      datasetId = folder_synID,
+						      filenames = as.list(filename_list),
+						      useAnnotations = F,
+						      sheetUrl = F)
       ### make sure not scalar if length of list is 1 in R
       ## add in the step to convert names later ###
 

--- a/app.R
+++ b/app.R
@@ -382,10 +382,7 @@ schema_to_display_lookup <- data.frame(schema_name, display_name)
       manifest_url <- metadata_model$getModelManifest(paste0(config$community," ", input$template_type), 
 						      template_type, 
 						      filenames = as.list(filename_list),
-						      datasetId = folder_synID,
-						      filenames = as.list(filename_list),
-						      useAnnotations = F,
-						      sheetUrl = T)
+						      datasetId = folder_synID)
       ### make sure not scalar if length of list is 1 in R
       ## add in the step to convert names later ###
 


### PR DESCRIPTION
I think this is a breaking change; it refers to parameters that don't exist in the current getModelManifest function, so will require users to update to a version of schematic with the changes proposed in PR 456: https://github.com/Sage-Bionetworks/schematic/pull/456


These changes surface the sheet_url and use_annotations parameters from some of the lower level functions for the shiny app. I found through testing that I needed to surface the sheet_url parameter, otherwise getModelManifest returned a manifest_df and not a manifest_url to the shiny app. I am not 100% sure why that started happening after adding the use_annotations parameter. 