### PR TITLE
Show selection box

### DIFF
--- a/functions/create_validation_msg.R
+++ b/functions/create_validation_msg.R
@@ -2,6 +2,8 @@ validationResult <- function(valRes, template, inFile) {
   validation_res <- NULL
   error_msg <- NULL
   help_msg <- NULL
+  outMsg <- NULL
+  errorDT <- NULL
   errorType <- NULL
 
   if (!is.null(inFile) & !is.null(template)) {
@@ -69,14 +71,14 @@ validationResult <- function(valRes, template, inFile) {
       # errorDT <- errorDT[order(errorDT$Column),]
     } else {
       validation_res <- "valid"
+      errorType <- "No Error"
     }
 
     # combine all error messages into one, add an extra empty line to bottom
-    outMsg <- paste0(
-      "Your metadata is <b>", validation_res, "</b> !!!", "<br><br>",
-      error_msg, "<br><br>",
-      help_msg
-    )
+    outMsg <- paste0(c(
+      paste0("Your metadata is <b>", validation_res, "</b> !!!"),
+      error_msg, help_msg
+    ), collapse = "<br><br>")
   }
 
   return(list(

--- a/functions/dc_waiter.R
+++ b/functions/dc_waiter.R
@@ -23,8 +23,6 @@ dc_waiter <- function(stage = c("show", "update", "hide"),
   # log in screen
   if (isLogin) {
     # The message on initial loading page are not customizable
-    if (!is.null(msg)) message("message for log in screen can be changed in dc_waiter.R")
-
     if (stage == "show") {
       waiter_show_on_load(
         html = tagList(

--- a/functions/dc_waiter.R
+++ b/functions/dc_waiter.R
@@ -3,7 +3,7 @@
 
 dc_waiter <- function(stage = c("show", "update", "hide"),
                       isLogin = FALSE, isPass = TRUE, usrName = NULL,
-                      sleep = 2, msg = NULL) {
+                      sleep = 2, msg = NULL, spin = NULL) {
   # validate arguments
   if (!is.logical(isLogin)) stop("isLogin must be a boolean")
   if (!is.logical(isPass)) stop("isPass must be a boolean")
@@ -11,7 +11,8 @@ dc_waiter <- function(stage = c("show", "update", "hide"),
   if (!stage %in% c("show", "update", "hide")) {
     stop("Please provide a value for stage: 'show', 'update' or 'hide'.")
   }
-
+  if (is.null(msg)) msg <- "Loading ..."
+  if (is.null(spin)) spin <- spin_plus()
   # if "hide", proceed hiding process immediately and exit function
   if (stage == "hide") {
     Sys.sleep(sleep)
@@ -52,16 +53,15 @@ dc_waiter <- function(stage = c("show", "update", "hide"),
     }
   } else {
     # other loading screens
-    if (is.null(msg)) msg <- "Loading ..."
 
     if (stage == "show") {
       waiter_show(
-        html = tagList(spin_plus(), br(), h3(msg)),
+        html = tagList(spin, br(), h3(msg)),
         color = "rgba(66, 72, 116, .9)"
       )
     } else {
       Sys.sleep(2) # has to put at least 2s before to make update work
-      waiter_update(html = tagList(spin_loaders(32), br(), h3(msg)))
+      waiter_update(html = tagList(spin, br(), h3(msg)))
       Sys.sleep(sleep)
       waiter_hide()
     }

--- a/global.R
+++ b/global.R
@@ -18,6 +18,7 @@ suppressPackageStartupMessages({
   library(waiter)
   library(readr)
   library(sass)
+  library(shinydashboardPlus)
 })
 
 # APP_URL <- "https://shinypro.synapse.org/users/spatil/HTAN-oauth/"
@@ -81,3 +82,6 @@ reticulate::use_condaenv("data_curator_env_oauth")
 # Import functions/modules
 source_files <- list.files(c("functions", "modules"), pattern = "*\\.R$", recursive = TRUE, full.names = TRUE)
 sapply(source_files, FUN = source)
+
+# Global variables
+datatypes <- c("project", "folder", "template")

--- a/renv.lock
+++ b/renv.lock
@@ -4,7 +4,11 @@
     "Repositories": [
       {
         "Name": "CRAN",
-        "URL": "https://ftp.osuosl.org/pub/cran"
+        "URL": "https://cran.rstudio.com"
+      },
+      {
+        "Name": "Sage",
+        "URL": "http://ran.synapse.org"
       }
     ]
   },
@@ -36,6 +40,34 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "08588806cba69f04797dab50627428ed"
+    },
+    "R.cache": {
+      "Package": "R.cache",
+      "Version": "0.15.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "e92a8ea8388c47c82ed8aa435ed3be50"
+    },
+    "R.methodsS3": {
+      "Package": "R.methodsS3",
+      "Version": "1.8.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "4bf6453323755202d5909697b6f7c109"
+    },
+    "R.oo": {
+      "Package": "R.oo",
+      "Version": "1.24.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "5709328352717e2f0a9c012be8a97554"
+    },
+    "R.utils": {
+      "Package": "R.utils",
+      "Version": "2.10.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "a9e316277ff12a43997266f2f6567780"
     },
     "R6": {
       "Package": "R6",
@@ -212,6 +244,13 @@
       "Repository": "CRAN",
       "Hash": "83ab58a0518afe3d17e41da01af13b60"
     },
+    "fresh": {
+      "Package": "fresh",
+      "Version": "0.2.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "fa54367040deb4537da49b7ac0ee5770"
+    },
     "fs": {
       "Package": "fs",
       "Version": "1.4.2",
@@ -253,13 +292,6 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "3d59212f2814d65dff517e6899813c58"
-    },
-    "highr": {
-      "Package": "highr",
-      "Version": "0.8",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "4dc5bb88961e347a0f4d8aad597cbfac"
     },
     "hms": {
       "Package": "hms",
@@ -315,13 +347,6 @@
       "Repository": "CRAN",
       "Hash": "2657f20b9a74c996c602e74ebe540b06"
     },
-    "knitr": {
-      "Package": "knitr",
-      "Version": "1.29",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "e5f4c41c17df8cdf7b0df12117c0d99a"
-    },
     "labeling": {
       "Package": "labeling",
       "Version": "0.3",
@@ -359,17 +384,10 @@
     },
     "magrittr": {
       "Package": "magrittr",
-      "Version": "1.5",
+      "Version": "2.0.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "1bb58822a20301cee84a41678e25d9b7"
-    },
-    "markdown": {
-      "Package": "markdown",
-      "Version": "1.1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "61e4a10781dd00d7d81dd06ca9b94e95"
+      "Hash": "41287f1ac7d28a92f0a286ed507928d3"
     },
     "mgcv": {
       "Package": "mgcv",
@@ -438,8 +456,8 @@
       "Package": "plotly",
       "Version": "4.9.2.9000",
       "Source": "GitHub",
-      "Remotes": "rstudio/thematic, ramnathv/htmlwidgets",
       "RemoteType": "github",
+      "Remotes": "rstudio/thematic, ramnathv/htmlwidgets",
       "RemoteHost": "api.github.com",
       "RemoteRepo": "plotly",
       "RemoteUsername": "ropensci",
@@ -503,6 +521,13 @@
       "Repository": "CRAN",
       "Hash": "2639976851f71f330264a9c9c3d43a61"
     },
+    "rematch2": {
+      "Package": "rematch2",
+      "Version": "2.1.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "76c9e04c712a05848ae7a23d2f170a40"
+    },
     "renv": {
       "Package": "renv",
       "Version": "0.11.0-3",
@@ -535,13 +560,6 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "c06d2a6887f4b414f8e927afd9ee976a"
-    },
-    "rmarkdown": {
-      "Package": "rmarkdown",
-      "Version": "2.3",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "202260e1b2c410edc086d5b8f1ed946e"
     },
     "rprojroot": {
       "Package": "rprojroot",
@@ -584,6 +602,13 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "133639dc106955eee4ffb8ec73edac37"
+    },
+    "shinydashboardPlus": {
+      "Package": "shinydashboardPlus",
+      "Version": "2.0.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "1abe63cd90fe33d3ca211525a0b39af9"
     },
     "shinyjs": {
       "Package": "shinyjs",
@@ -632,6 +657,13 @@
       "Repository": "CRAN",
       "Hash": "0759e6b6c0957edb1311028a49a35e76"
     },
+    "styler": {
+      "Package": "styler",
+      "Version": "1.4.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "2ec6308547ffe73208cef3ef3766fc33"
+    },
     "sys": {
       "Package": "sys",
       "Version": "3.3",
@@ -666,13 +698,6 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "6ea435c354e8448819627cf686f66e0a"
-    },
-    "tinytex": {
-      "Package": "tinytex",
-      "Version": "0.24",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "8f24b65b86f4d6d7b1e2d8a4ce2c02fb"
     },
     "utf8": {
       "Package": "utf8",

--- a/server.R
+++ b/server.R
@@ -119,6 +119,7 @@ shinyServer(function(input, output, session) {
     })
   })
 
+
   # Adjust header selection dropdown based on tabs
   observe({
     if (input[["tabs"]] %in% c("tab_instructions", "tab_data")) {
@@ -157,12 +158,6 @@ shinyServer(function(input, output, session) {
     }
   })
 
-  # update selected folder ID
-  observeEvent(input$dropdown_folder, {
-    # TODO: check how different from using rectivateValues()
-    folder_synID <<- datatype_list[["folders_namedList"]][[input$dropdown_folder]]
-  })
-
   ######## Update Template ########
   # update selected schema template name
   observeEvent(input$dropdown_template, {
@@ -185,6 +180,9 @@ shinyServer(function(input, output, session) {
 
     # loading screen for template link generation
     dc_waiter("show", msg = "Generating link...")
+
+    # update selected folder ID
+    folder_synID <<- datatype_list[["folders_namedList"]][[input$dropdown_folder]]
 
     if (is.null(input$dropdown_template)) {
       output$text_download <- renderUI({
@@ -337,6 +335,8 @@ shinyServer(function(input, output, session) {
     # the type to filter (eg assay) on could probably also be a config choice
     assay_schemas <- config$manifest_schemas$display_name[config$manifest_schemas$type ==
       "assay"]
+    # folder_ID has not been updated yet
+    if (is.null(folder_synID)) folder_synID <<- datatype_list[["folders_namedList"]][[input$dropdown_folder]]
 
     # and adds entityID, saves it as synapse_storage_manifest.csv, then associates
     # with synapse files

--- a/ui.R
+++ b/ui.R
@@ -8,17 +8,40 @@
 #
 # https://www.synapse.org
 
-ui <- dashboardPage(
+ui <- shinydashboardPlus::dashboardPage(
   skin = "purple",
   dashboardHeader(
     titleWidth = 250,
-    title = "Data Curator",
+    title = tagList(
+      span(class = "logo-lg", "Data Curator"),
+      span(class = "logo-mini", "DCA")
+    ),
+    leftUi = tagList(
+      dropdownBlock(
+        id = "header_selection_dropdown",
+        title = "Selection",
+        icon = icon("sliders"),
+        badgeStatus = "info",
+        fluidRow(
+          lapply(datatypes, function(x) {
+            div(
+              id = paste0("hover_text_", x),
+              selectizeInput(
+                inputId = paste0("header_dropdown_", x),
+                label = NULL,
+                choices = character(0)
+              )
+            )
+          }),
+          actionButton(inputId = "btn_header_update", label = NULL, icon = icon("sync-alt"))
+        )
+      )
+    ),
     tags$li(
-      class = "dropdown",
+      class = "dropdown", id = "HTAN_logo",
       tags$a(
         href = "https://humantumoratlas.org/",
         target = "_blank",
-        ## insert links and logos of your choice, this is just an example
         tags$img(
           height = "40px", alt = "HTAN LOGO",
           src = "HTAN_text_logo.png"
@@ -62,17 +85,16 @@ ui <- dashboardPage(
   dashboardBody(
     tags$head(
       tags$style(sass(sass_file("www/scss/main.scss"))),
-      singleton(
-        includeScript("www/readCookie.js")
-      )
+      singleton(includeScript("www/js/readCookie.js")),
+      singleton(includeScript("www/js/onclick.js"))
     ),
-    uiOutput("title"),
     use_notiflix_report(),
     use_waiter(),
     tabItems(
       # First tab content
       tabItem(
         tabName = "tab_instructions",
+        uiOutput("title"),
         h2("Instructions for the Data Curator App:"),
         h3(
           "1. Go to",
@@ -106,7 +128,11 @@ ui <- dashboardPage(
               label = "Project:",
               choices = "Generating..."
             ),
-            uiOutput("folders"),
+            selectizeInput(
+              inputId = "dropdown_folder",
+              label = "Folder:",
+              choices = "Generating..."
+            ),
             helpText(
               "If your recently updated folder does not appear, please wait for Synapse to sync and refresh"
             )
@@ -116,7 +142,11 @@ ui <- dashboardPage(
             solidHeader = TRUE,
             width = 6,
             title = "Choose a Metadata Template Type: ",
-            uiOutput("manifest_display_name")
+            selectizeInput(
+              inputId = "dropdown_template",
+              label = "Template:",
+              choices = "Generating..."
+            )
           )
         ),
         switchTabUI("switchTab2", direction = "both")

--- a/www/js/onclick.js
+++ b/www/js/onclick.js
@@ -1,0 +1,17 @@
+// this script is to adjust the distance btw #header_selection_dropdown and content
+
+$(document).on('shiny:connected', function (event) {
+  $('#header_selection_dropdown').on('click', function () {
+    if ($('#header_selection_dropdown')[0].className != 'dropdown open') {
+      $('.content').css('padding-top', '50px')
+    } else {
+      $('.content').css('padding-top', '15px')
+    }
+  })
+});
+
+$(document).on('click', function (e) {
+  if (e.target.id != '#header_selection_dropdown') {
+    $('.content').css('padding-top', '15px');
+  }
+})

--- a/www/js/readCookie.js
+++ b/www/js/readCookie.js
@@ -17,18 +17,18 @@
 // }
 
 // read the user login token from a cookie (new protocol) 
-Shiny.addCustomMessageHandler("readCookie", function(message) {
-    readCookie();
+Shiny.addCustomMessageHandler("readCookie", function (message) {
+  readCookie();
 });
 
 function readCookie() {
   const xhr = new XMLHttpRequest();
-  const url='https://www.synapse.org/Portal/sessioncookie';
+  const url = 'https://www.synapse.org/Portal/sessioncookie';
   xhr.withCredentials = true;
-  xhr.onreadystatechange = function() {
-     if (xhr.readyState == XMLHttpRequest.DONE) {
-         Shiny.onInputChange("cookie",xhr.responseText);
-     }
+  xhr.onreadystatechange = function () {
+    if (xhr.readyState == XMLHttpRequest.DONE) {
+      Shiny.onInputChange("cookie", xhr.responseText);
+    }
   }
   xhr.open("GET", url);
   xhr.send();

--- a/www/scss/basic/_animation.scss
+++ b/www/scss/basic/_animation.scss
@@ -1,0 +1,18 @@
+@keyframes fadeIn {
+  0% {transform:scale(0); opacity: 0}
+  30% {transform: scale(0.3)}
+  70% {transform: scale(0.7)}
+  100% {transform: scale(1); opacity: 1}
+}
+
+@keyframes TransitioningBackground {
+  0% {
+    background-position: 1% 0%;
+  }
+  50% {
+    background-position: 99% 100%;
+  }
+  100% {
+    background-position: 1% 0%;
+  }
+}

--- a/www/scss/basic/_button.scss
+++ b/www/scss/basic/_button.scss
@@ -1,1 +1,62 @@
 // styles of button are collected in here 
+
+
+
+// https://paigen11.medium.com/
+#btn_header_update
+{
+  position: relative;
+  background: #27022d;
+  color: #fff;
+  text-decoration: none;
+  letter-spacing: 1px;
+  border-radius: 5px;
+  box-shadow: $simple_shadow;
+  transition: 500ms;
+  overflow: hidden;
+  // for background color shift
+  background-image: (linear-gradient(270deg, #8e9ac2, #42579a));
+  background-size: 400% 400%;
+  animation: TransitioningBackground 10s ease infinite;
+
+  &:hover {
+    background-image: (linear-gradient(to left, #2d8fe5, #d155b8));
+    transform: scale(1.05);
+    cursor: pointer;
+  }
+  // shine animation left side
+  &::before {
+    content: '';
+    display: block;
+    position: absolute;
+    background: rgba(255, 255, 255, 0.5);
+    width: 60px;
+    height: 100%;
+    top: 0;
+    filter: blur(30px);
+    transform: translateX(-100px) skewX(-15deg);
+  }
+  // shine animation right side
+  &::after {
+    content: '';
+    display: block;
+    position: absolute;
+    background: rgba(255, 255, 255, 0.2);
+    width: 30px;
+    height: 100%;
+    top: 0;
+    filter: blur(5px);
+    transform: translateX(-100px) skewX(-15deg);
+  }
+
+  &::before,
+  &::after {
+    transform: translateX(300px) skewX(-15deg);
+    transition: 0.7s;
+  }
+}
+
+
+
+
+

--- a/www/scss/basic/_variables.scss
+++ b/www/scss/basic/_variables.scss
@@ -7,3 +7,9 @@ $notif_process_col: #F7DC6F;
 $notif_success_col: #82E0AA;
 $footer_col: #465362;
 $footer_bg_col: #D0D6DC;
+
+// box shadow
+$simple_shadow: 0 10px 10px -5px;
+$float_shadow: 0px 0.0625em 0.0625em rgba(0, 0, 0, 0.25),
+               0px 0.125em 0.5em rgba(0, 0, 0, 0.25),
+               0px 0px 0px 1px inset rgba(255, 255, 255, 0.1);

--- a/www/scss/main.scss
+++ b/www/scss/main.scss
@@ -3,14 +3,11 @@
 
 // dashboard sections
 @import 'section/header';
-@import 'section/navigation';
 @import 'section/sidebar';
 @import 'section/content';
 @import 'section/footer';
 
 // feature styles
+@import 'basic/animation';
 @import 'basic/button';
 @import 'basic/message';
-
-
-

--- a/www/scss/section/_content.scss
+++ b/www/scss/section/_content.scss
@@ -6,3 +6,12 @@
     padding: 10px 0;
 }
 
+.option {
+    &:hover, &:focus {
+        transform: scale(1.02);
+        font-size: 1.1em;
+        box-shadow: $float_shadow;
+        border-radius: 20px;
+        transition: transform 50ms;
+    }
+}

--- a/www/scss/section/_header.scss
+++ b/www/scss/section/_header.scss
@@ -1,9 +1,63 @@
 .main-header {
-    max-height: 50px;
+    
+  .logo {
+    font-size: 1.8em;
+  }
 
-    .logo {
-        height: 70px;
-        font-size: 21px;
-        padding-top: 10px;
+  #HTAN_logo a {
+    height: 50px;
+    display: table-cell;
+    vertical-align: middle;
+    padding: 0 15px;
+  }
+
+  .dropdown-menu {
+    left: auto !important; // stick with the button left
+    box-shadow: $float_shadow;
+    animation: fadeIn 100ms;
+
+  
+    ul.menu {
+
+      padding: 0 5px !important;
+      // reset all margin
+      & * {
+        margin: 0px;
+      }
+      
+      &>div, .row {
+        display: flex;
+        align-items: center;
+        justify-content: flex-start;
+        width: 100% !important;
+      }
+
+      .shiny-input-container{
+        width: 250px;
+        margin: 5px;
+        height: 34px; // remove extra space bottom
+      }
     }
+  }
+}
+
+.main-header .dropdown-menu #hover_text_folder div .selectize-dropdown {
+  // due to long names, increase the width of folder dropdown in header
+  width: 150% !important;
+}
+
+
+@media (max-width:1146px){
+  .shiny-input-container{
+    width: 200px !important;
+  }
+}
+
+@media (max-width:973px){
+  ul.menu {
+    &>div, .row {
+      flex-wrap: wrap;
+      justify-content: center
+    }
+  }
 }

--- a/www/scss/section/_navigation.scss
+++ b/www/scss/section/_navigation.scss
@@ -1,3 +1,0 @@
-.navbar {
-    min-height: 50px !important
-}

--- a/www/scss/section/_sidebar.scss
+++ b/www/scss/section/_sidebar.scss
@@ -1,7 +1,7 @@
-.sidebar-toggle {
-    height: 15px;
-    padding-top: 25px !important
-}
+// .sidebar-toggle {
+//     height: 15px;
+//     padding-top: 25px !important
+// }
 
 /*** Sidebar ***/
 .left-side, .main-sidebar {


### PR DESCRIPTION
This PR is to add a new exciting feature related to #39, #71: "display the users' selections of projects, folders and templates". The purpose is to provide the information in the third & forth tabs and remind users what datatypes they have selected to avoid errors in validation process, such as 'mismatched templates". We also would like to let the users be able to update their choices.

We have tried to put the box that shows the selections in the *sidebar*. However, some names are super long and cannot be fit the sidebar. To best utilize the space of header, we decide to make a dropdown menu in the header. 

Hence, here are the demos:
- The `header-dropdown-button` ("selection") will only show in the "download spreadsheet tab" and "validate & submit tab". And users need to click the button to display the selections
- Once the box pops in, the content will responsively move down a little bit to avoid overlaps. Box can be closed either by clicking the button again or anywhere outside the box
<p align="center">
  <img src="https://user-images.githubusercontent.com/73901500/118165842-c8f6b100-b3f2-11eb-83f1-076f078c7ef3.gif" width="45%">
  <img src="https://user-images.githubusercontent.com/73901500/118165849-cb590b00-b3f2-11eb-871a-ade4825c90f3.gif" width="45%">
<p/> 

- The `header-dropdown-button` will automatically sync with the selections in the second tab, but will not work in the opposite direction, unless the users click the "update button" on the right and confirm the changes

<p align="center">
<img src="https://user-images.githubusercontent.com/73901500/118166411-723da700-b3f3-11eb-9cd7-c5d6b73d1b3c.gif" width="80%">
<p/> 

This PR is based on the PR #164 - code refactor round 2. I now compare to `shiny-server-develop` branch, but we can discuss whether we would like to merge this PR to the code factor PR branch first or wait the PR #164 merged first. Please feel free to comment or suggest. Otherwise, we can discuss in the code review meeting.


