### PR TITLE
Avoid errors when users search outside of dropdown choices

### DIFF
--- a/server.R
+++ b/server.R
@@ -104,7 +104,7 @@ shinyServer(function(input, output, session) {
         }
 
         ### updates project dropdown
-        updateSelectizeInput(session, "var", choices = sort(names(projects_namedList)))
+        updateSelectInput(session, "var", choices = sort(names(projects_namedList)))
 
         ### update waiter loading screen once login successful
         waiter_update(html = tagList(

--- a/ui.R
+++ b/ui.R
@@ -115,7 +115,7 @@ ui <- dashboardPage(
             solidHeader = TRUE,
             width = 6,
             title = "Choose a Project and Folder: ",
-            selectizeInput(
+            selectInput(
               inputId = "var",
               label = "Project:",
               choices = "Generating..."


### PR DESCRIPTION
fix #162 

The issue is when users are trying to type/search something that are not in the `project` dropdown list, there will be some errors. The reason is that if anything outside of list was used,  the dropdown button would have become `''`. It will break at  https://github.com/Sage-Bionetworks/data_curator/blob/6f9db3f42f9ed19147da351cb34ecaa826a4392c/server.R#L94-L102

I decide to not use `validate` or provide a better error message. For one reason, `validate` will not properly pop up message if we don't use `renderUI` in the future PR. For another, we would need to add extra validation on download/validation buttons if users just leave blank and proceed. To make things simpler, I just changed `selectiveInput` to `selectInput` and it can solve this issue.

![fix162](https://user-images.githubusercontent.com/73901500/118275817-ea0fde00-b494-11eb-9e11-5116f381d54d.gif)

