### PR TITLE
Validation Tab > add row index back + compress duplicated errors

### DIFF
--- a/functions/utils.R
+++ b/functions/utils.R
@@ -6,3 +6,21 @@ list2Vector <- function(list) {
   }
   return(vector)
 }
+
+# convert long string from "x1, x2, x3, x4, x5" into "x1, x2 ... x5" 
+TruncateEllipsis <- function(string, max, split_pattern = NULL) {
+  
+  if (!is.null(split_pattern)) {
+    string <- str_split(string, split_pattern)
+  }
+  
+  sapply(string,function(i) {
+    n <- length(i)
+    if (n > max) {
+      firstMaX <- str_c(i[1:(max-1)], collapse = ", ")
+      str_c(c(firstMaX, "...", i[n]), collapse = " ")
+    } else {
+      str_c(i, collapse = ", ")
+    }
+  })
+}

--- a/functions/validationResult.R
+++ b/functions/validationResult.R
@@ -66,14 +66,14 @@ validationResult <- function(valRes, template, inFile) {
         Error = sapply(valRes, function(i) i[[3]])
       )
 
-      # collapse similiar errors with one row
+      # collapse similiar errors into one row
       errorDT <- errorDT %>%
         mutate(Options = gsub("^'.*?'(.*)", "\\1", Error)) %>%
         group_by(Column, Options) %>%
         summarise(
           n = n_distinct(Value),
-          Row = str_c(unique(Row), collapse = ", "),
-          Value = str_c(unique(Value), collapse = ", "),
+          Row = str_c(unique(Row), collapse = ", ") %>% TruncateEllipsis(10, ", "),
+          Value = str_c(unique(Value), collapse = ", ") %>% TruncateEllipsis(10, ", "),
           .groups = "drop"
         ) %>%
         mutate(

--- a/functions/validationResult.R
+++ b/functions/validationResult.R
@@ -67,18 +67,19 @@ validationResult <- function(valRes, template, inFile) {
       )
 
       # collapse similiar errors with one row
-      errorDT <- errorDT %>% 
-        mutate(Options = gsub("^'.*?'(.*)", "\\1", Error)) %>% 
+      errorDT <- errorDT %>%
+        mutate(Options = gsub("^'.*?'(.*)", "\\1", Error)) %>%
         group_by(Column, Options) %>%
         summarise(
           n = n_distinct(Value),
-          Row=str_c(unique(Row), collapse=", "),
-          Value=str_c(unique(Value), collapse=", "),
-          .groups = 'drop') %>%
+          Row = str_c(unique(Row), collapse = ", "),
+          Value = str_c(unique(Value), collapse = ", "),
+          .groups = "drop"
+        ) %>%
         mutate(
-          Options=ifelse(n > 1, str_replace(Options, "^ is", " are"), Options),
-          Error=str_c(sQuote(Value), Options)
-          ) %>%
+          Options = ifelse(n > 1, str_replace(Options, "^ is", " are"), Options),
+          Error = str_c(sQuote(Value), Options)
+        ) %>%
         ungroup() %>%
         dplyr::select(Row, Column, Value, Error)
 
@@ -86,7 +87,6 @@ validationResult <- function(valRes, template, inFile) {
       errorDT <- errorDT[order(match(errorDT$Column, colnames(inFile))), ]
       # TODO: to reduce parameter, sort just based on alphabetic
       # errorDT <- errorDT[order(errorDT$Column),]
-
     } else {
       validation_res <- "valid"
       errorType <- "No Error"

--- a/modules/DTable.R
+++ b/modules/DTable.R
@@ -6,7 +6,7 @@ DTableUI <- function(id) {
 }
 
 DTableServer <- function(id, data,
-                         rownames = FALSE, caption = NULL,
+                         rownames = TRUE, caption = NULL,
                          options = list(lengthChange = FALSE, scrollX = TRUE),
                          highlight = NULL, hightlight.col = NULL, hightlight.value = NULL) {
   if (!is.null(highlight)) {

--- a/modules/DTable.R
+++ b/modules/DTable.R
@@ -6,7 +6,7 @@ DTableUI <- function(id) {
 }
 
 DTableServer <- function(id, data,
-                         rownames = TRUE, caption = NULL,
+                         rownames = TRUE, caption = NULL, filter = "top",
                          options = list(lengthChange = FALSE, scrollX = TRUE),
                          highlight = NULL, hightlight.col = NULL, hightlight.value = NULL) {
   if (!is.null(highlight)) {
@@ -21,6 +21,7 @@ DTableServer <- function(id, data,
   df <- datatable(data,
     caption = caption,
     rownames = rownames,
+    filter = filter,
     options = options
   )
 

--- a/modules/csvInfile.R
+++ b/modules/csvInfile.R
@@ -35,7 +35,12 @@ csvInfileServer <- function(id, na = c("", "NA"), colsAsCharacters = FALSE, keep
         # remove empty rows/columns where readr called it 'X'[digit] for unnamed col
         infile <- infile[, !grepl("^X", colnames(infile))]
         infile <- infile[rowSums(is.na(infile)) != ncol(infile), ]
+        # add 1 to row index to match spreadsheet's row index
+        rownames(infile) <- as.numeric(rownames(infile)) + 1
+
+        return(infile)
       })
+
       return(list(
         raw = reactive({
           input$file

--- a/server.R
+++ b/server.R
@@ -199,7 +199,7 @@ shinyServer(function(input, output, session) {
         synStore_obj,
         folder_synID
       )
-      
+
       # get file list in selected folder
       # don't put in the observation of folder dropdown
       # it will crash if users switch folders too often
@@ -218,7 +218,7 @@ shinyServer(function(input, output, session) {
 
       # generate link
       output$text_download <- renderUI({
-        tags$a(href = manifest_url, manifest_url, target = "_blank") 
+        tags$a(href = manifest_url, manifest_url, target = "_blank")
       })
     }
 
@@ -262,10 +262,11 @@ shinyServer(function(input, output, session) {
       # output error messages as data table if it is invalid value type
       # render empty if error is not "invaid value" type - ifelse() will not work
       if (valRes$errorType == "Invalid Value") {
-        DTableServer("tbl_validate", valRes$errorDT, rownames = FALSE, filter = "none",
+        DTableServer("tbl_validate", valRes$errorDT,
+          rownames = FALSE, filter = "none",
           options = list(
             pageLength = 50, scrollX = TRUE,
-            scrollY = min(50 * length(annotation_status), 400), lengthChange = FALSE,
+            scrollY = min(50 * nrow(valRes$errorDT), 400), lengthChange = FALSE,
             info = FALSE, searching = FALSE
           )
         )

--- a/server.R
+++ b/server.R
@@ -264,6 +264,7 @@ shinyServer(function(input, output, session) {
       if (valRes$errorType == "Invalid Value") {
         DTableServer("tbl_validate", valRes$errorDT,
           rownames = FALSE, filter = "none",
+          caption = "View all the error(s) highlighted in the preview table above",
           options = list(
             pageLength = 50, scrollX = TRUE,
             scrollY = min(50 * nrow(valRes$errorDT), 400), lengthChange = FALSE,

--- a/server.R
+++ b/server.R
@@ -262,7 +262,7 @@ shinyServer(function(input, output, session) {
       # output error messages as data table if it is invalid value type
       # render empty if error is not "invaid value" type - ifelse() will not work
       if (valRes$errorType == "Invalid Value") {
-        DTableServer("tbl_validate", valRes$errorDT,
+        DTableServer("tbl_validate", valRes$errorDT, rownames = FALSE,
           options = list(
             pageLength = 50, scrollX = TRUE,
             scrollY = min(50 * length(annotation_status), 400), lengthChange = FALSE,

--- a/server.R
+++ b/server.R
@@ -262,7 +262,7 @@ shinyServer(function(input, output, session) {
       # output error messages as data table if it is invalid value type
       # render empty if error is not "invaid value" type - ifelse() will not work
       if (valRes$errorType == "Invalid Value") {
-        DTableServer("tbl_validate", valRes$errorDT, rownames = FALSE,
+        DTableServer("tbl_validate", valRes$errorDT, rownames = FALSE, filter = "none",
           options = list(
             pageLength = 50, scrollX = TRUE,
             scrollY = min(50 * length(annotation_status), 400), lengthChange = FALSE,


### PR DESCRIPTION
- fixes #169 
  - add search bar on each column
  - add row index back to the preview table (starting with 2 to match spreadsheet row index)

<img width="1666" alt="Screen Shot 2021-10-05 at 9 29 12 AM" src="https://user-images.githubusercontent.com/73901500/136032534-7cacd4d4-617d-4d36-b507-3253b9765024.png">

- fixes #144 
  - similar errors will be collapsed into one row
  - truncate the invalid row indexes and values with ellipsis
<img width="1180" alt="Screen Shot 2021-10-08 at 9 52 47 AM" src="https://user-images.githubusercontent.com/73901500/136569141-b23029bf-7773-4fc8-95e7-309450e1bdc3.png">

