### PR TITLE
Fix loading screen & add extra validations during initial loading

### DIFF
--- a/functions/dcWaiter.R
+++ b/functions/dcWaiter.R
@@ -1,12 +1,14 @@
 # This is script to wrap up the waiter screen for data curator app
 # TODO: maybe we could split into UI and server if we need
 
-dcWaiter <- function(stage = c("show", "update", "hide"),
-                     isLogin = FALSE, isPass = TRUE, usrName = NULL,
+dcWaiter <- function(stage = c("show", "update", "hide"), landing = FALSE, userName = NULL,
+                     isLogin = TRUE, isCertified = TRUE, isPermission = TRUE,
                      sleep = 2, msg = NULL, spin = NULL) {
   # validate arguments
+  if (!is.logical(landing)) stop("landing must be a boolean")
   if (!is.logical(isLogin)) stop("isLogin must be a boolean")
-  if (!is.logical(isPass)) stop("isPass must be a boolean")
+  if (!is.logical(isCertified)) stop("isCertified must be a boolean")
+  if (!is.logical(isPermission)) stop("isPermission must be a boolean")
   if (!is.numeric(sleep)) stop("sleep must be a numeric")
   if (!stage %in% c("show", "update", "hide")) {
     stop("Please provide a value for stage: 'show', 'update' or 'hide'.")
@@ -20,9 +22,9 @@ dcWaiter <- function(stage = c("show", "update", "hide"),
     return(waiter_hide())
   }
 
-  # log in screen
-  if (isLogin) {
-    # The message on initial loading page are not customizable
+  # first loading screen of app
+  if (landing) {
+  
     if (stage == "show") {
       waiter_show_on_load(
         html = tagList(
@@ -31,28 +33,49 @@ dcWaiter <- function(stage = c("show", "update", "hide"),
         ),
         color = "#424874"
       )
-    } else if (isPass) {
+    # } else if (!isLogin) {
+    #   # when user is not login
+    #   waiter_update(html = tagList(
+    #     img(src = "img/synapse_logo.png", height = "120px"),
+    #     h3("Looks like you're not logged in!"), 
+    #     span("Please ", 
+    #       a("login", href = "https://www.synapse.org/#!LoginPlace:0", target = "_blank"),
+    #       " to Synapse, then refresh this page."
+    #     )
+    #   ))
+    } else if (!isCertified) {
+      # when user is not certified synapse user
       waiter_update(html = tagList(
         img(src = "img/synapse_logo.png", height = "120px"),
-        h3(sprintf("Welcome, %s!", usrName))
+        h3("Looks like you're not a certified synapse user!"),
+        span("Please follow the ", 
+          a("instruction", 
+            href = "https://help.synapse.org/docs/User-Account-Tiers.2007072795.html#UserAccountTiers-CertifiedUsers", 
+            target = "_blank"
+          ),
+          " to become a certified user, then refresh this page."
+        )
+      ))
+    } else if (!isPermission) {
+      # when user is not certified synapse user
+      waiter_update(html = tagList(
+        img(src = "img/synapse_logo.png", height = "120px"),
+        h3("Looks like you dont have access to fileview"),
+        span("placeholder ...")
+      ))
+    } else {
+      # success loading page; userName needed to provide
+      waiter_update(html = tagList(
+        img(src = "img/synapse_logo.png", height = "120px"),
+        h3(sprintf("Welcome, %s!", userName))
       ))
       Sys.sleep(sleep)
       waiter_hide()
-    } else {
-      # ensure the synapse logo image is stored in www/
-      waiter_update(html = tagList(
-        img(src = "img/synapse_logo.png", height = "120px"),
-        h3("Looks like you're not logged in!"), span(
-          "Please ", a("login",
-            href = "https://www.synapse.org/#!LoginPlace:0", target = "_blank"
-          ),
-          " to Synapse, then refresh this page."
-        )
-      ))
     }
-  } else {
-    # other loading screens
 
+  } else {
+  
+    # other loading screens
     if (stage == "show") {
       waiter_show(
         html = tagList(spin, br(), h3(msg)),

--- a/functions/dcWaiter.R
+++ b/functions/dcWaiter.R
@@ -47,7 +47,7 @@ dcWaiter <- function(stage = c("show", "update", "hide"), landing = FALSE, userN
       # when user is not certified synapse user
       waiter_update(html = tagList(
         img(src = "img/synapse_logo.png", height = "120px"),
-        h3("Looks like you're not a certified synapse user!"),
+        h3("Looks like you're not a synapse certified user!"),
         span("Please follow the ", 
           a("instruction", 
             href = "https://help.synapse.org/docs/User-Account-Tiers.2007072795.html#UserAccountTiers-CertifiedUsers", 

--- a/functions/synapse_func_alias.py
+++ b/functions/synapse_func_alias.py
@@ -5,4 +5,4 @@ syn_login = syn.login
 syn_getUserProfile = syn.getUserProfile
 syn_tableQuery = syn.tableQuery
 syn_get = syn.get
-
+syn_is_certified = syn.is_certified

--- a/ui.R
+++ b/ui.R
@@ -227,7 +227,7 @@ ui <- shinydashboardPlus::dashboardPage(
       )
     ),
     # waiter loading screen
-    dcWaiter("show", isLogin = TRUE)
+    dcWaiter("show", landing = TRUE)
   )
 )
 


### PR DESCRIPTION
- fixes #106
- improve the loading screen function
  - add checkpoints on permission to fileview and certification of users
  - change 'login' to 'landing'
- fixes: tryCatch not prevent app from crashing and show proper loading screen