### PR TITLE
Adjust regex to fit new validation error result

### DIFF
--- a/functions/validationResult.R
+++ b/functions/validationResult.R
@@ -60,16 +60,15 @@ validationResult <- function(valRes, template, inFile) {
       }
 
       errorDT <- lapply(valRes, function(i) {
-        error_row <- i[[1]] 
-        error_col <- i[[2]]
-        # get invalid value
-        error_val <- inFile[as.numeric(error_row) - 1, error_col]
         tibble(
-          Row = error_row,
-          Column = error_col,
-          Value = error_val,
+          Row = i[[1]],
+          Column = i[[2]],
+          Value = i[[4]][[1]],
           Error = i[[3]]
-        ) %>% mutate(across(everything(), as.character))
+        ) %>%
+        # ensure highlight function to work
+        # convert to all characters since {inFile} in preview are all characters
+        mutate(across(everything(), as.character))
       }) %>% bind_rows()
 
       # collapse similiar errors into one row

--- a/functions/validationResult.R
+++ b/functions/validationResult.R
@@ -63,12 +63,11 @@ validationResult <- function(valRes, template, inFile) {
         tibble(
           Row = i[[1]],
           Column = i[[2]],
-          Value = i[[4]][[1]],
+          # ensure highlight function to work
+          # convert to all characters since {inFile} in preview are all characters
+          Value = as.character(i[[4]][[1]]),
           Error = i[[3]]
-        ) %>%
-        # ensure highlight function to work
-        # convert to all characters since {inFile} in preview are all characters
-        mutate(across(everything(), as.character))
+        )
       }) %>% bind_rows()
 
       # collapse similiar errors into one row

--- a/functions/validationResult.R
+++ b/functions/validationResult.R
@@ -59,34 +59,33 @@ validationResult <- function(valRes, template, inFile) {
         )
       }
 
-      errorDT <- data.frame(
-        Row = sapply(valRes, function(i) i[[1]]),
-        Column = sapply(valRes, function(i) i[[2]]),
-        Value = sapply(valRes, function(i) i[[4]][[1]]),
-        Error = sapply(valRes, function(i) i[[3]])
-      )
+      errorDT <- lapply(valRes, function(i) {
+        error_row <- i[[1]] 
+        error_col <- i[[2]]
+        error_val <- inFile[as.numeric(error_row) - 1, error_col]
+        tibble(
+          Row = error_row,
+          Column = error_col,
+          Value = error_val,
+          Error = i[[3]]
+        ) %>% mutate(across(everything(), as.character))
+      }) %>% bind_rows()
 
       # collapse similiar errors into one row
       errorDT <- errorDT %>%
-        mutate(Options = gsub("^'.*?'(.*)", "\\1", Error)) %>%
-        group_by(Column, Options) %>%
+        mutate(Error = gsub(".*(not .*)[[:punct:]]", "\\1", Error)) %>%
+        group_by(Column, Error) %>%
         summarise(
-          n = n_distinct(Value),
           Row = str_c(unique(Row), collapse = ", ") %>% TruncateEllipsis(10, ", "),
           Value = str_c(unique(Value), collapse = ", ") %>% TruncateEllipsis(10, ", "),
           .groups = "drop"
-        ) %>%
-        mutate(
-          Options = ifelse(n > 1, str_replace(Options, "^ is", " are"), Options),
-          Error = str_c(sQuote(Value), Options)
         ) %>%
         ungroup() %>%
         dplyr::select(Row, Column, Value, Error)
 
       # sort rows based on input column names
       errorDT <- errorDT[order(match(errorDT$Column, colnames(inFile))), ]
-      # TODO: to reduce parameter, sort just based on alphabetic
-      # errorDT <- errorDT[order(errorDT$Column),]
+
     } else {
       validation_res <- "valid"
       errorType <- "No Error"

--- a/functions/validationResult.R
+++ b/functions/validationResult.R
@@ -63,11 +63,12 @@ validationResult <- function(valRes, template, inFile) {
         tibble(
           Row = i[[1]],
           Column = i[[2]],
-          # ensure highlight function to work
-          # convert to all characters since {inFile} in preview are all characters
-          Value = as.character(i[[4]][[1]]),
+          Value = i[[4]][[1]],
           Error = i[[3]]
-        )
+        ) %>%
+        # ensure highlight function to work
+        # convert to all characters since {inFile} in preview are all characters
+        mutate(across(everything(), as.character))
       }) %>% bind_rows()
 
       # collapse similiar errors into one row

--- a/functions/validationResult.R
+++ b/functions/validationResult.R
@@ -62,6 +62,7 @@ validationResult <- function(valRes, template, inFile) {
       errorDT <- lapply(valRes, function(i) {
         error_row <- i[[1]] 
         error_col <- i[[2]]
+        # get invalid value
         error_val <- inFile[as.numeric(error_row) - 1, error_col]
         tibble(
           Row = error_row,
@@ -73,7 +74,7 @@ validationResult <- function(valRes, template, inFile) {
 
       # collapse similiar errors into one row
       errorDT <- errorDT %>%
-        mutate(Error = gsub(".*(not .*)[[:punct:]]", "\\1", Error)) %>%
+        mutate(Error = gsub(".*(not.*)\\.?$", "\\1", Error)) %>%
         group_by(Column, Error) %>%
         summarise(
           Row = str_c(unique(Row), collapse = ", ") %>% TruncateEllipsis(10, ", "),

--- a/functions/validationResult.R
+++ b/functions/validationResult.R
@@ -2,9 +2,9 @@ validationResult <- function(valRes, template, inFile) {
   validation_res <- NULL
   error_msg <- NULL
   help_msg <- NULL
-  outMsg <- NULL
-  errorDT <- NULL
-  errorType <- NULL
+  out_msg <- NULL
+  error_table <- NULL
+  error_type <- NULL
 
   if (!is.null(inFile) && !is.null(template) && length(inFile) != 0) {
     if (length(valRes) != 0) {
@@ -26,7 +26,7 @@ validationResult <- function(valRes, template, inFile) {
 
       if (length(inx_mt) > 0) {
         # mismatched error(s): selected template mismatched with validating template
-        errorType <- "Mismatched Template"
+        error_type <- "Mismatched Template"
         # get all mismatched components
         error_values <- sapply(valRes[inx_mt], function(x) x[[4]][[1]]) %>%
           unique()
@@ -47,32 +47,30 @@ validationResult <- function(valRes, template, inFile) {
         )
       } else if (length(inx_ws) > 0) {
         # wrong schema error(s): validating metadata miss any required columns
-        errorType <- "Wrong Schema"
+        error_type <- "Wrong Schema"
         error_msg <- "The submitted metadata does not contain all required column(s)."
         help_msg <- "Please check that you used the correct template in the <b>'Get Metadata Template'</b> tab and
 						ensure your metadata contains all required columns."
       } else {
-        errorType <- "Invalid Value"
+        error_type <- "Invalid Value"
         error_msg <- paste0(
           "The submitted metadata have ", length(valRes),
           " errors."
         )
       }
 
-      errorDT <- lapply(valRes, function(i) {
-        tibble(
-          Row = i[[1]],
-          Column = i[[2]],
-          Value = i[[4]][[1]],
-          Error = i[[3]]
-        ) %>%
-        # ensure highlight function to work
-        # convert to all characters since {inFile} in preview are all characters
-        mutate(across(everything(), as.character))
-      }) %>% bind_rows()
+      # create table to display errors for users
+      error_table <- lapply(valRes, function(i) {
+        data.frame(Row = as.numeric(i[[1]]), Column = i[[2]], Value = i[[4]][[1]], Error = i[[3]])
+      }) %>% bind_rows() 
+
+      # create list for hightlight function; key: error_column, value: error_value
+      highlight_values <- sapply(unique(error_table$Column), function(col) {
+        error_table$Value[error_table$Column == col]
+      })
 
       # collapse similiar errors into one row
-      errorDT <- errorDT %>%
+      error_table <- error_table %>%
         mutate(Error = gsub(".*(not.*)\\.?$", "\\1", Error)) %>%
         group_by(Column, Error) %>%
         summarise(
@@ -82,17 +80,17 @@ validationResult <- function(valRes, template, inFile) {
         ) %>%
         ungroup() %>%
         dplyr::select(Row, Column, Value, Error)
-
+    
       # sort rows based on input column names
-      errorDT <- errorDT[order(match(errorDT$Column, colnames(inFile))), ]
+      error_table <- error_table[order(match(error_table$Column, colnames(inFile))), ]
 
     } else {
       validation_res <- "valid"
-      errorType <- "No Error"
+      error_type <- "No Error"
     }
 
     # combine all error messages into one, add an extra empty line to bottom
-    outMsg <- paste0(c(
+    out_msg <- paste0(c(
       paste0("Your metadata is <b>", validation_res, "</b> !!!"),
       error_msg, help_msg
     ), collapse = "<br><br>")
@@ -100,8 +98,9 @@ validationResult <- function(valRes, template, inFile) {
 
   return(list(
     validationRes = validation_res,
-    outMsg = outMsg,
-    errorDT = errorDT,
-    errorType = errorType
+    outMsg = out_msg,
+    errorDT = error_table,
+    errorHighlight = highlight_values,
+    errorType = error_type
   ))
 }

--- a/global.R
+++ b/global.R
@@ -5,6 +5,7 @@ suppressPackageStartupMessages({
   library(yaml)
   library(shinyjs)
   library(dplyr)
+  library(tidyr)
   library(shinythemes)
   library(shinydashboard)
   library(stringr)

--- a/modules/DTable.R
+++ b/modules/DTable.R
@@ -1,5 +1,14 @@
-# This moduel is to peformrender DT table function for preview/highlight
-
+#' This moduel is to wrap some of DT table functions, especially for hightlight functions
+#' 
+#' @param id id name of this module
+#' @param data a data object (either a matrix or a data frame)
+#' @param rownames TRUE (show row names) or FALSE (hide row names)
+#' @param caption a character vector or a tag object generated from \code{htmltools::tags$caption()}
+#' @param filter whether/where to use column filters, either "none", "top" or "bottom"
+#' @param options a list of initialization options (see https://datatables.net/reference/option/) 
+#' @param highlight whether to highlight cells in the table, either "full" (highlight entired table) or "partial" (highlight certain cells based on \code{highlightValues})
+#' @param highlightValues a list of values to be highlighted; each element of list following by key (column names) and value (a vector of values)
+#' @return a reactive table
 DTableUI <- function(id) {
   ns <- NS(id)
   DT::DTOutput(ns("table"))
@@ -8,38 +17,39 @@ DTableUI <- function(id) {
 DTableServer <- function(id, data,
                          rownames = TRUE, caption = NULL, filter = "top",
                          options = list(lengthChange = FALSE, scrollX = TRUE),
-                         highlight = NULL, hightlight.col = NULL, hightlight.value = NULL) {
-  if (!is.null(highlight)) {
-    if (!highlight %in% c("full", "partial")) {
-      Stop("Please choose a value for highlight: 'full', 'partial'.")
-    }
-
-    column <- hightlight.col
-    value <- hightlight.value
-  }
-
-  df <- datatable(data,
-    caption = caption,
-    rownames = rownames,
-    filter = filter,
-    options = options
-  )
-
-  if (!is.null(highlight)) {
-    if (highlight == "full") {
-      df <- df %>%
-        formatStyle(1, target = "row", backgroundColor = "yellow")
-    } else if (highlight == "partial") {
-      df <- df %>%
-        formatStyle(column, backgroundColor = styleEqual(
-          value, rep("yellow", length(value))
-        ))
-    }
-  }
+                         highlight = NULL, highlightValues = NULL) {
 
   moduleServer(
     id,
     function(input, output, session) {
+
+      df <- datatable(data,
+        caption = caption,
+        rownames = rownames,
+        filter = filter,
+        options = options
+      )
+
+      if (!is.null(highlight)) {
+        
+        match.arg(highlight, c("full", "partial"))
+
+        if (highlight == "full") {
+
+          df <- df %>% formatStyle(1, target = "row", backgroundColor = "yellow")
+
+        } else if (highlight == "partial") {
+
+          # iterate each col to avoid messing around same value in multiple columns
+          for (col in names(highlightValues)) {
+
+            values <- highlightValues[[col]]
+            df <- df %>%
+              formatStyle(col, backgroundColor = styleEqual(values, rep("yellow", length(values))))
+          }
+        }
+      }
+
       output$table <- renderDT(df)
     }
   )

--- a/modules/csvInfile.R
+++ b/modules/csvInfile.R
@@ -28,8 +28,8 @@ csvInfileServer <- function(id, na = c("", "NA"), colsAsCharacters = FALSE, keep
         }
 
         if (keepBlank) {
-          # change NA to blank to match schema output)
-          infile <- infile %>% replace(., is.na(.), "")
+          # change NA to blank to match schematic output
+          infile <- infile %>% mutate(across(everything(), ~replace_na(., "")))
         }
 
         # remove empty rows/columns where readr called it 'X'[digit] for unnamed col

--- a/server.R
+++ b/server.R
@@ -268,7 +268,7 @@ shinyServer(function(input, output, session) {
         template_schema_name()
       )
     )
-
+    logjs(annotation_status)
     # validation messages
     valRes <- validationResult(annotation_status, input$dropdown_template, inFile$data())
     ValidationMsgServer("text_validate", valRes, input$dropdown_template, inFile$data())

--- a/server.R
+++ b/server.R
@@ -295,9 +295,9 @@ shinyServer(function(input, output, session) {
       if (valRes$errorType == "Wrong Schema") {
         DTableServer("tbl_preview", data = inFile$data(), highlight = "full")
       } else {
-        DTableServer("tbl_preview",
-          data = inFile$data(),
-          highlight = "partial", hightlight.col = valRes$errorDT$Column, hightlight.value = valRes$errorDT$Value
+        DTableServer(
+          "tbl_preview", data = inFile$data(), 
+          highlight = "partial", highlightValues = valRes$errorHighlight
         )
       }
 

--- a/server.R
+++ b/server.R
@@ -268,7 +268,7 @@ shinyServer(function(input, output, session) {
         template_schema_name()
       )
     )
-    logjs(annotation_status)
+
     # validation messages
     valRes <- validationResult(annotation_status, input$dropdown_template, inFile$data())
     ValidationMsgServer("text_validate", valRes, input$dropdown_template, inFile$data())


### PR DESCRIPTION
**Regex rule**: 
- "HTAN Data File ID": `regex match ^HTA[0-9]*(_[0-9]+)*$`
- "Read Length": `regex match ^\\d+$`

The fourth element of validation result for the regex error is not the invalid value. 

<img width="877" alt="Screen Shot 2021-12-13 at 2 52 20 PM" src="https://user-images.githubusercontent.com/73901500/146037411-3a0699a7-5c63-4f4c-863b-e8b2969ccedb.png">

1. ~To ensure the highlighting function in preview table work, modify the codes to find the invalid values.~
2. To ensure all current possible validation error messages can be collapsed, modify the regex to truncate error messages into, `not .....`
3. Change highlight functions in `DTable.R` to iterate/specify each column names, in order to avoid the same value highlighted in wrong columns
4. Fix `csvInfile.R` to properly replace `NA` with `empty string`

Updated Preview
---
<img width="1288" alt="Screen Shot 2021-12-16 at 4 49 49 PM" src="https://user-images.githubusercontent.com/73901500/146455096-25a12bbe-587f-41d9-8eb4-397318406664.png">

