### PR TITLE
Add schematic and schema version

### DIFF
--- a/www/config.json
+++ b/www/config.json
@@ -4,5 +4,7 @@
       {"display_name": "Patient", "schema_name": "Patient", "type": "clinical"},
       {"display_name": "Biospecimen Tier 1 & 2", "schema_name": "Biospecimen", "type": "biospecimen"}
   ],
-  "community" : "Example"
+  "community": "Example",
+  "schema": "v0.1.0",
+  "schematic_service": "v1"
 }


### PR DESCRIPTION
- fixes #294 

Note: Since we will replace schematic python package with API service, "schematic_service" is used. We have not yet had versions for data models, so "v0.1.0" is dummy tag for now.