### PR TITLE
Fix warning about old icons in shinydashboardPlus

### DIFF
--- a/install-pkgs.R
+++ b/install-pkgs.R
@@ -12,17 +12,21 @@ cran <- c(
   "DT==0.20",
   "jsonlite==1.7.3",
   "reticulate==1.23",
-  "shinydashboardPlus==2.0.3",
+  # "shinydashboardPlus==2.0.3",
   "waiter==0.2.5",
   "readr==2.1.1",
-  "sass==0.4.0",
+  "sass==0.4.1",
   "remotes==2.4.2",
   "rsconnect==0.8.25",
   "png==0.1.7",
   "tidyr==1.1.4"
 )
 gh <- c(
-  "dreamRs/shinypop"
+  "dreamRs/shinypop",
+  # switch back to use cran install 'shinydashboardPlus'
+  # once they make a release to fix icons
+  # https://github.com/RinteRface/shinydashboardPlus
+  "RinteRface/shinydashboardPlus"
 )
 
 # The binary package distributions from R Studio dramatically speed up installation time


### PR DESCRIPTION
Fix the warning:

```
This Font Awesome icon ('gears') does not exist:
* if providing a custom `html_dependency` these `name` checks can 
  be deactivated with `verify_fa = FALSE`
```

>Shiny 1.7 uses the latest font awesome icons v5.15. In this version, some old names are gone and need to be replaced. For example, gears needs to be cogs.

The latest `shinydashboardPlus` has addressed this issue.