### PR TITLE
Add argument names on submission function

### DIFF
--- a/functions/metadata_model.py
+++ b/functions/metadata_model.py
@@ -1,6 +1,6 @@
 from schematic.models.metadata import MetadataModel
 from schematic import CONFIG
-
+from schematic.schemas.generator import SchemaGenerator
 
 config = CONFIG.load_config("schematic_config.yml")
 
@@ -11,3 +11,6 @@ manifest_title = CONFIG["manifest"]["title"]
 manifest_data_type = CONFIG["manifest"]["data_type"][0]
 
 metadata_model = MetadataModel(inputMModelLocation, inputMModelLocationType)
+
+# create schema generator object for associateMetadataWithFiles
+schema_generator = SchemaGenerator(inputMModelLocation)

--- a/server.R
+++ b/server.R
@@ -386,6 +386,7 @@ shinyServer(function(input, output, session) {
 
       # associates metadata with data and returns manifest id
       manifest_id <- syn_store$associateMetadataWithFiles(
+        schemaGenerator = schema_generator,
         metadataManifestPath = "./tmp/synapse_storage_manifest.csv",
         datasetId = folder_synID(),
         manifest_record_type = "table"
@@ -420,6 +421,7 @@ shinyServer(function(input, output, session) {
 
       # associates metadata with data and returns manifest id
       manifest_id <- syn_store$associateMetadataWithFiles(
+        schemaGenerator = schema_generator,
         metadataManifestPath = "./tmp/synapse_storage_manifest.csv",
         datasetId = folder_synID(),
         manifest_record_type = "table"

--- a/server.R
+++ b/server.R
@@ -80,7 +80,7 @@ shinyServer(function(input, output, session) {
       message("'synapse_driver' fails, run 'synapse_driver' to see detailed error")
       dcWaiter("update", landing = TRUE, isPermission = FALSE)
     } else {
-      projects_list <- synapse_driver$getStorageProjects(syn_store)
+      projects_list <- syn_store$getStorageProjects()
       datatype_list$projects <<- list2Vector(projects_list)
 
       # updates project dropdown
@@ -155,7 +155,7 @@ shinyServer(function(input, output, session) {
       projectID <- datatype_list$projects[[input[[paste0(x, "project")]]]]
 
       # gets folders per project
-      folder_list <- synapse_driver$getStorageDatasetsInProject(syn_store, projectID) %>% list2Vector()
+      folder_list <- syn_store$getStorageDatasetsInProject(projectID) %>% list2Vector()
 
       # updates foldernames
       updateSelectInput(session, paste0(x, "folder"), choices = sort(names(folder_list)))
@@ -192,10 +192,7 @@ shinyServer(function(input, output, session) {
     if (input$tabs == "tab_template") {
       dcWaiter("show", msg = paste0("Getting files in ", input$dropdown_folder, "..."))
       # get file list in selected folder
-      file_list <- synapse_driver$getFilesInStorageDataset(
-        syn_store,
-        folder_synID()
-      )
+      file_list <- syn_store$getFilesInStorageDataset(folder_synID())
       datatype_list$files <<- list2Vector(file_list)
       dcWaiter("hide")
     }
@@ -369,7 +366,7 @@ shinyServer(function(input, output, session) {
           quote = TRUE, row.names = FALSE, na = ""
         )
       } else {
-        file_list <- synapse_driver$getFilesInStorageDataset(syn_store, folder_synID())
+        file_list <- syn_store$getFilesInStorageDataset(folder_synID())
         datatype_list$files <<- list2Vector(file_list)
 
         # better filename checking is needed
@@ -386,8 +383,7 @@ shinyServer(function(input, output, session) {
       }
 
       # associates metadata with data and returns manifest id
-      manifest_id <- synapse_driver$associateMetadataWithFiles(
-        self = syn_store,
+      manifest_id <- syn_store$associateMetadataWithFiles(
         metadataManifestPath = "./tmp/synapse_storage_manifest.csv",
         datasetId = folder_synID(),
         manifest_record_type = "table"
@@ -421,8 +417,7 @@ shinyServer(function(input, output, session) {
       )
 
       # associates metadata with data and returns manifest id
-      manifest_id <- synapse_driver$associateMetadataWithFiles(
-        self = syn_store,
+      manifest_id <- syn_store$associateMetadataWithFiles(
         metadataManifestPath = "./tmp/synapse_storage_manifest.csv",
         datasetId = folder_synID(),
         manifest_record_type = "table"

--- a/server.R
+++ b/server.R
@@ -229,8 +229,9 @@ shinyServer(function(input, output, session) {
     dcWaiter("show", msg = "Generating link...")
 
     manifest_url <-
-      metadata_model$getModelManifest(paste0(config$community, " ", input$dropdown_template),
-        template_schema_name(),
+      metadata_model$getModelManifest(
+        title = paste0(config$community, " ", input$dropdown_template),
+        rootNode = template_schema_name(),
         filenames = switch((template_type == "file") + 1,
           NULL,
           as.list(names(datatype_list$files))
@@ -280,8 +281,8 @@ shinyServer(function(input, output, session) {
     annotation_status <-
       tryCatch(
         metadata_model$validateModelManifest(
-          inFile$raw()$datapath,
-          template_schema_name(),
+          manifestPath = inFile$raw()$datapath,
+          rootNode = template_schema_name(),
           restrict_rules = TRUE, # set true to disable great expectation
           project_scope = list(project_synID)
         ),
@@ -328,10 +329,11 @@ shinyServer(function(input, output, session) {
     # loading screen for Google link generation
     dcWaiter("show", msg = "Generating link...")
 
-    filled_manifest <- metadata_model$populateModelManifest(paste0(
-      config$community,
-      " ", input$dropdown_template
-    ), inFile$raw()$datapath, template_schema_name())
+    filled_manifest <- metadata_model$populateModelManifest(
+      title = paste0(config$community, " ", input$dropdown_template),
+      manifestPath = inFile$raw()$datapath,
+      rootNode = template_schema_name()
+    )
 
     # rerender and change button to link
     output$val_gsheet <- renderUI({

--- a/server.R
+++ b/server.R
@@ -387,9 +387,9 @@ shinyServer(function(input, output, session) {
 
       # associates metadata with data and returns manifest id
       manifest_id <- synapse_driver$associateMetadataWithFiles(
-        synStore_obj,
-        "./tmp/synapse_storage_manifest.csv",
-        folder_synID(),
+        self = synStore_obj,
+        metadataManifestPath = "./tmp/synapse_storage_manifest.csv",
+        datasetId = folder_synID(),
         manifest_record_type = "table"
       )
       manifest_path <- tags$a(href = paste0("https://www.synapse.org/#!Synapse:", manifest_id), manifest_id, target = "_blank")
@@ -422,9 +422,9 @@ shinyServer(function(input, output, session) {
 
       # associates metadata with data and returns manifest id
       manifest_id <- synapse_driver$associateMetadataWithFiles(
-        synStore_obj,
-        "./tmp/synapse_storage_manifest.csv",
-        folder_synID(),
+        self = synStore_obj,
+        metadataManifestPath = "./tmp/synapse_storage_manifest.csv",
+        datasetId = folder_synID(),
         manifest_record_type = "table"
       )
       manifest_path <- tags$a(href = paste0("https://www.synapse.org/#!Synapse:", manifest_id), manifest_id, target = "_blank")


### PR DESCRIPTION
The changes in this PR:
1. Add `SchemaGenerator` argument and identify the argument names as well for `associateMetadataWithFiles` to address this [issue](https://github.com/ncihtan/HTAN-data-curator/issues/22#issuecomment-1191934454)
2. Also add argument names to schematic model's functions, just in case
3. Change to use the loaded storage object (`syn_store`) directly, instead of calling `SynapseStorage`'s functions (`synapse_driver`) and providing `syn_store` for ` self` argument every time.  Below are a quick benchmarking results on `getStorageProjects` and `getFilesInStorageDataset`. It shows using function from configured `syn_store` directly executes is ~ half second faster. 

benchmarking results 
```console
benchmark("syn_store" = {
            projects_list <- syn_store$getStorageProjects()
          },
          "synapse_driver" = {
            projects_list <- synapse_driver$getStorageProjects(syn_store)
          },
          replications = 100,
          columns = c("test", "replications", "elapsed")
          )

            test replications elapsed
1      syn_store          100  65.455
2 synapse_driver          100  66.075
```


```console
benchmark("syn_store" = {
             file_list <- syn_store$getFilesInStorageDataset(
               "syn24180957"
             )
           },
           "synapse_driver" = {
             file_list <- synapse_driver$getFilesInStorageDataset(
               syn_store,
               "syn24180957"
             )
           },
           replications = 100,
           columns = c("test", "replications", "elapsed")
           )

            test replications elapsed
1      syn_store          100 546.535
2 synapse_driver          100 546.890
```