### PR TITLE
Add testing instance to shinyapps.io deploy

### DIFF
--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -103,6 +103,7 @@ jobs:
             release_type <- "release"
           } else if (refName == "main") { release_type <- "staging"
           } else release_type <- "testing"
+          message(sprintf("Deploying to %s instance.", release_type))
           repo <- Sys.getenv("GITHUB_REPOSITORY")
           appName <- strsplit(repo, "/")[[1]][2]
           appName <- paste(appName, release_type, sep = "-")

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -52,17 +52,20 @@ jobs:
         run: |
           # has to activate each bash step
           source .venv/bin/activate
-          # use 'poetry' to install schematic from the corresponding branch 
-          pip3 install poetry
-          SCHEM_BRANCH=develop
-          if [[ $GITHUB_REF_NAME == v*.*.* ]]; then
-            SCHEM_BRANCH=main
+          # use 'poetry' to install schematic dev schematic 
+          # If commit is tagged for release or in main branch, install schematic from pypi
+          if [[ $GITHUB_REF_NAME == v*.*.* ]] || [[ $GITHUB_REF_NAME == main ]]; then
+            echo Installing pypi version of schematic
+            git clone --single-branch --branch main https://github.com/Sage-Bionetworks/schematic.git
+            pip3 install schematicpy
+          else
+            pip3 install poetry
+            echo Installing develop branch of schematic from github
+            git clone --single-branch --branch $SCHEM_BRANCH https://github.com/Sage-Bionetworks/schematic.git
+            cd schematic
+            poetry build
+            pip3 install dist/schematicpy-1.0.0-py3-none-any.whl
           fi
-          echo Installing $SCHEM_BRANCH branch of schematic
-          git clone --single-branch --branch $SCHEM_BRANCH https://github.com/Sage-Bionetworks/schematic.git
-          cd schematic
-          poetry build
-          pip3 install dist/schematicpy-1.0.0-py3-none-any.whl
 
       - name: Set Configurations for Schematic
         shell: bash
@@ -95,12 +98,14 @@ jobs:
         run: |
           # if there is a tag, 'refName' will be tag name
           refName <- Sys.getenv("GITHUB_REF_NAME")
+          # if tag is v*.*.*, deploy to prod, if main to staging, otherwise to test
+          if (!grepl("v[0-9]+.[0-9]+.[0-9]+", refName)) {
+            release_type <- "release"
+          } else if (refName == "main") { release_type <- "staging"
+          } else release_type <- "testing"
           repo <- Sys.getenv("GITHUB_REPOSITORY")
           appName <- strsplit(repo, "/")[[1]][2]
-          # if tag is v*.*.*, deploy to prod, otherwise to staging
-          if (!grepl("v[0-9]+.[0-9]+.[0-9]+", refName)) {
-            appName <- paste(appName, "staging", sep = "-")
-          }
+          appName <- paste(appName, release_type, sep = "-")
           rsConnectUser <- "${{ secrets.RSCONNECT_USER }}"
           rsConnectToken <- "${{ secrets.RSCONNECT_TOKEN }}"
           rsConnectSecret <- "${{ secrets.RSCONNECT_SECRET }}"

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -97,16 +97,20 @@ jobs:
         shell: Rscript {0}
         run: |
           # if there is a tag, 'refName' will be tag name
+          repo <- Sys.getenv("GITHUB_REPOSITORY")
+          appName <- strsplit(repo, "/")[[1]][2]
           refName <- Sys.getenv("GITHUB_REF_NAME")
           # if tag is v*.*.*, deploy to prod, if main to staging, otherwise to test
           if (!grepl("v[0-9]+.[0-9]+.[0-9]+", refName)) {
-            release_type <- "release"
-          } else if (refName == "main") { release_type <- "staging"
-          } else release_type <- "testing"
-          message(sprintf("Deploying to %s instance.", release_type))
-          repo <- Sys.getenv("GITHUB_REPOSITORY")
-          appName <- strsplit(repo, "/")[[1]][2]
-          appName <- paste(appName, release_type, sep = "-")
+            message("Deploying release version of app")
+          } else if (refName == "main") {
+            appName <- paste(appName, "staging", sep = "-")
+            message("Deploying staging version of app")
+          } else {
+            appName <- paste(appName, "testing", sep = "-")
+            message("Deploying testing version of app")
+          }
+          message(sprintf("Deploying to %s instance.", appName))
           rsConnectUser <- "${{ secrets.RSCONNECT_USER }}"
           rsConnectToken <- "${{ secrets.RSCONNECT_TOKEN }}"
           rsConnectSecret <- "${{ secrets.RSCONNECT_SECRET }}"

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -101,7 +101,7 @@ jobs:
           appName <- strsplit(repo, "/")[[1]][2]
           refName <- Sys.getenv("GITHUB_REF_NAME")
           # if tag is v*.*.*, deploy to prod, if main to staging, otherwise to test
-          if (!grepl("v[0-9]+.[0-9]+.[0-9]+", refName)) {
+          if (grepl("v[0-9]+.[0-9]+.[0-9]+", refName)) {
             message("Deploying release version of app")
           } else if (refName == "main") {
             appName <- paste(appName, "staging", sep = "-")

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -9,7 +9,7 @@ on:
   push:
     branches:
       - main
-      - develop
+      - develop*
     tags:
       - v*.*.*
     paths-ignore:
@@ -52,9 +52,14 @@ jobs:
         run: |
           # has to activate each bash step
           source .venv/bin/activate
-          # use 'poetry' to install schematic from the develop branch 
+          # use 'poetry' to install schematic from the corresponding branch 
           pip3 install poetry
-          git clone --single-branch --branch develop https://github.com/Sage-Bionetworks/schematic.git
+          SCHEM_BRANCH=develop
+          if [[ $GITHUB_REF_NAME == v*.*.* ]]; then
+            SCHEM_BRANCH=main
+          fi
+          echo Installing $SCHEM_BRANCH branch of schematic
+          git clone --single-branch --branch $SCHEM_BRANCH https://github.com/Sage-Bionetworks/schematic.git
           cd schematic
           poetry build
           pip3 install dist/schematicpy-1.0.0-py3-none-any.whl

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -61,7 +61,7 @@ jobs:
           else
             pip3 install poetry
             echo Installing develop branch of schematic from github
-            git clone --single-branch --branch $SCHEM_BRANCH https://github.com/Sage-Bionetworks/schematic.git
+            git clone --single-branch --branch develop https://github.com/Sage-Bionetworks/schematic.git
             cd schematic
             poetry build
             pip3 install dist/schematicpy-1.0.0-py3-none-any.whl


### PR DESCRIPTION
This github workflow file for the shinyapps.io deploy adds a new testing instance. There are now 3 deployment types:

1. Release - triggered by a tagged commit. Deploys the tagged DCA branch and installs schematic from pypi
2. Staging - triggered by an untagged commit to main. Deploys the main DCA branch and installs schematic from pypi
3. Testing - triggered by an untagged commit to develop* branches. Deploys the branch and installs schematic develop branch using poetry.