### PR TITLE
Use the GitHub Token provided automatically by the GitHub Action inst…

### DIFF
--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -22,7 +22,7 @@ jobs:
     container: rocker/rstudio:4.1.2
     env:
       # This should not be necessary for installing from public repo's however remotes::install_github() fails without it.
-      GITHUB_PAT: ${{ secrets.REPO_PAT }}
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - name: Install System Dependencies


### PR DESCRIPTION
…ead of generating one and storing it as a secret.

GitHub Actions by default have an access token stored as the[ environment variable GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authentication). Use this instead of a user's PAT stored as a secret.