### PR TITLE
Add waiter when users have no access to any projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,14 +4,15 @@
 .DS_Store
 HTAN_test_shiny.Rproj
 app.bak.R
-get_manifest_anno.R
-manifest_url.txt
-**/config.json
-tmp/synapse_storage_manifest.csv
 .Rproj.user
 schematic/
-**/credentials.json
-**/schematic_service_account_creds.json
+data-models/
+great_expectations/
+*.json
+*.jsonld
+*.rds
+*.csv
+*.txt
 **/token.pickle
 **/.synapseConfig
 **/__pycache__
@@ -20,4 +21,3 @@ schematic_config.yml
 .project
 .settings/**
 .venv
-data-models/

--- a/functions/dcWaiter.R
+++ b/functions/dcWaiter.R
@@ -24,7 +24,6 @@ dcWaiter <- function(stage = c("show", "update", "hide"), landing = FALSE, userN
 
   # first loading screen of app
   if (landing) {
-  
     if (stage == "show") {
       waiter_show_on_load(
         html = tagList(
@@ -33,24 +32,15 @@ dcWaiter <- function(stage = c("show", "update", "hide"), landing = FALSE, userN
         ),
         color = "#424874"
       )
-    # } else if (!isLogin) {
-    #   # when user is not login
-    #   waiter_update(html = tagList(
-    #     img(src = "img/synapse_logo.png", height = "120px"),
-    #     h3("Looks like you're not logged in!"), 
-    #     span("Please ", 
-    #       a("login", href = "https://www.synapse.org/#!LoginPlace:0", target = "_blank"),
-    #       " to Synapse, then refresh this page."
-    #     )
-    #   ))
     } else if (!isCertified) {
       # when user is not certified synapse user
       waiter_update(html = tagList(
         img(src = "img/synapse_logo.png", height = "120px"),
         h3("Looks like you're not a synapse certified user!"),
-        span("Please follow the ", 
-          a("instruction", 
-            href = "https://help.synapse.org/docs/User-Account-Tiers.2007072795.html#UserAccountTiers-CertifiedUsers", 
+        span(
+          "Please follow the ",
+          a("instruction",
+            href = "https://help.synapse.org/docs/User-Account-Tiers.2007072795.html#UserAccountTiers-CertifiedUsers",
             target = "_blank"
           ),
           " to become a certified user, then refresh this page."
@@ -60,7 +50,7 @@ dcWaiter <- function(stage = c("show", "update", "hide"), landing = FALSE, userN
       # when user is not certified synapse user
       waiter_update(html = tagList(
         img(src = "img/synapse_logo.png", height = "120px"),
-        h3("Fileview Access Denied!"),
+        h3("Fileview/Project Access Denied!"),
         span("You may not have sufficient permissions for curation.
          Please contact your team and project administrators.")
       ))
@@ -73,9 +63,8 @@ dcWaiter <- function(stage = c("show", "update", "hide"), landing = FALSE, userN
       Sys.sleep(sleep)
       waiter_hide()
     }
-
   } else {
-  
+
     # other loading screens
     if (stage == "show") {
       waiter_show(

--- a/server.R
+++ b/server.R
@@ -73,22 +73,20 @@ shinyServer(function(input, output, session) {
 
     syn_login(authToken = access_token, rememberMe = FALSE)
 
-    access_res <- tryCatch(
+    datatype_list$projects <<- tryCatch(
       {
         # get syn storage
         syn_store <<- synapse_driver(access_token = access_token)
         # get user's common projects
-        datatype_list$projects <<- list2Vector(syn_store$getStorageProjects())
-        # assign 1 if no error
-        1L
+        list2Vector(syn_store$getStorageProjects())
       },
       error = function(e) {
         message(e$message)
-        return(0L)
+        return(NULL)
       }
     )
 
-    if (!access_res || length(datatype_list$projects) == 0) {
+    if (is.null(datatype_list$projects) || length(datatype_list$projects) == 0) {
       dcWaiter("update", landing = TRUE, isPermission = FALSE)
     } else {
       # updates project dropdown

--- a/server.R
+++ b/server.R
@@ -79,14 +79,16 @@ shinyServer(function(input, output, session) {
         syn_store <<- synapse_driver(access_token = access_token)
         # get user's common projects
         datatype_list$projects <<- list2Vector(syn_store$getStorageProjects())
+        # assign 1 if no error
+        1L
       },
       error = function(e) {
         message(e$message)
-        return(NULL)
+        return(0L)
       }
     )
 
-    if (is.null(access_res) || length(datatype_list$projects) == 0) {
+    if (!access_res || length(datatype_list$projects) == 0) {
       dcWaiter("update", landing = TRUE, isPermission = FALSE)
     } else {
       # updates project dropdown

--- a/server.R
+++ b/server.R
@@ -73,7 +73,7 @@ shinyServer(function(input, output, session) {
 
     syn_login(authToken = access_token, rememberMe = FALSE)
 
-    login_res <- tryCatch(
+    access_res <- tryCatch(
       {
         # get syn storage
         syn_store <<- synapse_driver(access_token = access_token)
@@ -86,7 +86,7 @@ shinyServer(function(input, output, session) {
       }
     )
 
-    if (is.null(login_res) || length(datatype_list$projects) == 0) {
+    if (is.null(access_res) || length(datatype_list$projects) == 0) {
       dcWaiter("update", landing = TRUE, isPermission = FALSE)
     } else {
       # updates project dropdown

--- a/server.R
+++ b/server.R
@@ -73,22 +73,22 @@ shinyServer(function(input, output, session) {
 
     syn_login(authToken = access_token, rememberMe = FALSE)
 
-    # updating syn storage
-    syn_store <<- tryCatch(
-      synapse_driver(access_token = access_token),
+    login_res <- tryCatch(
+      {
+        # get syn storage
+        syn_store <<- synapse_driver(access_token = access_token)
+        # get user's common projects
+        datatype_list$projects <<- list2Vector(syn_store$getStorageProjects())
+      },
       error = function(e) {
         message(e$message)
         return(NULL)
       }
     )
 
-    if (is.null(syn_store)) {
-      message("'synapse_driver' fails, run 'synapse_driver' to see detailed error")
+    if (is.null(login_res) || length(datatype_list$projects) == 0) {
       dcWaiter("update", landing = TRUE, isPermission = FALSE)
     } else {
-      projects_list <- syn_store$getStorageProjects()
-      datatype_list$projects <<- list2Vector(projects_list)
-
       # updates project dropdown
       lapply(c("header_dropdown_", "dropdown_"), function(x) {
         lapply(c(1, 3), function(i) {


### PR DESCRIPTION
- fixes #338

--- 
### ChangLogs of this PR:
- Clean up the `.gitignore` to exclude files based on the extensions
- Update the `tryCatch` when getting `syn_store` and add extra validation to check if number of projects users have access to
- Update waiter message to include "zero" projects error (Failed getting synapseStorage or at least one project will use this waiter - "Fileview/Project Access Denied!")