### PR TITLE
Set restrict_manifest=FALSE for submission

### DIFF
--- a/server.R
+++ b/server.R
@@ -399,7 +399,7 @@ shinyServer(function(input, output, session) {
         metadataManifestPath = "./tmp/synapse_storage_manifest.csv",
         datasetId = folder_synID(),
         manifest_record_type = "table",
-        restrict_manifest = TRUE
+        restrict_manifest = FALSE
       )
       manifest_path <- tags$a(href = paste0("https://www.synapse.org/#!Synapse:", manifest_id), manifest_id, target = "_blank")
 
@@ -435,7 +435,7 @@ shinyServer(function(input, output, session) {
         metadataManifestPath = "./tmp/synapse_storage_manifest.csv",
         datasetId = folder_synID(),
         manifest_record_type = "table",
-        restrict_manifest = TRUE
+        restrict_manifest = FALSE
       )
       manifest_path <- tags$a(href = paste0("https://www.synapse.org/#!Synapse:", manifest_id), manifest_id, target = "_blank")
 


### PR DESCRIPTION
This pr is to revert the changes from pr #394 to set `restrict_manifest` to FALSE in `associateMetadataWithFiles` function.

I didn't realize `restrict_manifest` will start the process to auto generate the jira ticket. To prevent from users to auto create many jira tickets for each submission, the `restrict_manifest` should be set as false (default) now.