### PR TITLE
Update package repo to focal for ubuntu 20

### DIFF
--- a/install-pkgs.R
+++ b/install-pkgs.R
@@ -32,7 +32,7 @@ gh <- c(
 # The binary package distributions from R Studio dramatically speed up installation time
 # For Ubuntu 18.04 (Bionic) it's https://packagemanager.rstudio.com/all/__linux__/bionic/latest
 # For Ubuntu 20.04 (Focal)  it's https://packagemanager.rstudio.com/all/__linux__/focal/latest
-options(repos = c(REPO_NAME = "https://packagemanager.rstudio.com/all/__linux__/bionic/latest", getOption("repos")))
+options(repos = c(REPO_NAME = "https://packagemanager.rstudio.com/all/__linux__/focal/latest", getOption("repos")))
 
 install.packages("remotes")
 invisible(


### PR DESCRIPTION
This fixes the error encountered during shinyapps.io deployment about stringr package missing