### PR TITLE
Add column name check before returning error table highlighting. This…

### DIFF
--- a/modules/DTable.R
+++ b/modules/DTable.R
@@ -37,6 +37,10 @@ DTableServer <- function(id, data,
 
           # iterate each col to avoid messing around same value in multiple columns
           for (col in names(highlightValues)) {
+            # This check prevents errors of the following form 
+            #   Warning: Error in name2int: You specified the columns: 0,
+            #   but the column names of the data are  , Component, ...
+            if (! col %in% names(data)) next()
             values <- highlightValues[[col]]
             # if NULL is provided for values, it will highlight entire columns
             if ("ht_entire_column" %in% values) style <- "yellow" else style <- styleEqual(values, rep("yellow", length(values)))


### PR DESCRIPTION
… prevents a bug where the table looks for a column that is not present. Fixes #438 