### PR TITLE
Added "service account creds.json" in shiny deployment workflow and deleted credentials.json and tocken.pickle

### DIFF
--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -71,7 +71,6 @@ jobs:
         run: |
           # write out configuration files using github secrets
           echo "${{ secrets.SCHEMATIC_SYNAPSE_CONFIG }}" > .synapseConfig
-          echo "${{ secrets.SCHEMATIC_CREDS_PATH }}" > credentials.json
 
       - name: Save service account credentials for Schematic
         id: create-json

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -71,10 +71,18 @@ jobs:
         run: |
           # write out configuration files using github secrets
           echo "${{ secrets.SCHEMATIC_SYNAPSE_CONFIG }}" > .synapseConfig
-          echo "${{ secrets.SCHEMATIC_SERVICE_ACCT_CREDS }}" > schematic_service_account_creds.json
-          echo "${{ secrets.SCHEMATIC_SERVICE_ACCT_CREDS }}" > schematic/schematic_service_account_creds.json
+          # echo "${{ secrets.SCHEMATIC_SERVICE_ACCT_CREDS }}" > schematic_service_account_creds.json
+          # echo "${{ secrets.SCHEMATIC_SERVICE_ACCT_CREDS }}" > schematic/schematic_service_account_creds.json
           echo "${{ secrets.SCHEMATIC_CREDS_PATH }}" > credentials.json
           echo "${{ secrets.SCHEMATIC_TOKEN_PICKLE }}" | base64 -d > token.pickle
+
+      - name: create-json
+        id: create-json
+        uses: jsdaniell/create-json@1.1.2
+        with:
+          name: "schematic_service_account_creds.json"
+          json: ${{ secrets.SCHEMATIC_SERVICE_ACCT_CREDS }}
+
 
       - name: Set Configurations for Data Model
         shell: bash

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -72,11 +72,10 @@ jobs:
           # write out configuration files using github secrets
           echo "${{ secrets.SCHEMATIC_SYNAPSE_CONFIG }}" > .synapseConfig
           echo "${{ secrets.SCHEMATIC_CREDS_PATH }}" > credentials.json
-          echo "${{ secrets.SCHEMATIC_TOKEN_PICKLE }}" | base64 -d > token.pickle
 
-      - name: create-json
+      - name: Save service account credentials for Schematic
         id: create-json
-        uses: jsdaniell/create-json@1.1.2
+        uses: jsdaniell/create-json@1.2.2
         with:
           name: "schematic_service_account_creds.json"
           json: ${{ secrets.SCHEMATIC_SERVICE_ACCT_CREDS }}

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -71,8 +71,6 @@ jobs:
         run: |
           # write out configuration files using github secrets
           echo "${{ secrets.SCHEMATIC_SYNAPSE_CONFIG }}" > .synapseConfig
-          # echo "${{ secrets.SCHEMATIC_SERVICE_ACCT_CREDS }}" > schematic_service_account_creds.json
-          # echo "${{ secrets.SCHEMATIC_SERVICE_ACCT_CREDS }}" > schematic/schematic_service_account_creds.json
           echo "${{ secrets.SCHEMATIC_CREDS_PATH }}" > credentials.json
           echo "${{ secrets.SCHEMATIC_TOKEN_PICKLE }}" | base64 -d > token.pickle
 

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -72,6 +72,7 @@ jobs:
           # write out configuration files using github secrets
           echo "${{ secrets.SCHEMATIC_SYNAPSE_CONFIG }}" > .synapseConfig
           echo "${{ secrets.SCHEMATIC_SERVICE_ACCT_CREDS }}" > schematic_service_account_creds.json
+          echo "${{ secrets.SCHEMATIC_SERVICE_ACCT_CREDS }}" > schematic/schematic_service_account_creds.json
           echo "${{ secrets.SCHEMATIC_CREDS_PATH }}" > credentials.json
           echo "${{ secrets.SCHEMATIC_TOKEN_PICKLE }}" | base64 -d > token.pickle
 

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Save service account credentials for Schematic
         id: create-json
-        uses: jsdaniell/create-json@1.2.2
+        uses: jsdaniell/create-json@1.1.2
         with:
           name: "schematic_service_account_creds.json"
           json: ${{ secrets.SCHEMATIC_SERVICE_ACCT_CREDS }}


### PR DESCRIPTION
Schematic is no longer using token.pickle and credentials.json because Google changes their authentication flow. I have updated DCA deployment workflow to use service_account_creds.json.

See issue from schematic here: https://github.com/Sage-Bionetworks/schematic/issues/1029