### PR TITLE
Add token.pickle and credentials.json so schematic doesn't break.

### DIFF
--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -71,6 +71,8 @@ jobs:
         run: |
           # write out configuration files using github secrets
           echo "${{ secrets.SCHEMATIC_SYNAPSE_CONFIG }}" > .synapseConfig
+          echo "${{ secrets.SCHEMATIC_CREDS_PATH }}" > credentials.json
+          echo "${{ secrets.SCHEMATIC_TOKEN_PICKLE }}" | base64 -d > token.pickle
 
       - name: Save service account credentials for Schematic
         id: create-json


### PR DESCRIPTION
Eventually schematic will only need `service_account_creds.json` to generate a google sheet, but the current release still fails without `token.pickle` and `credentials.json`. Adding these two files back to the deployment workflow so all versions of the app are stable.