### PR TITLE
Add option to use schematic with REST API or reticulate and multiple DCC

### DIFF
--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -23,9 +23,7 @@ jobs:
     env:
       # This should not be necessary for installing from public repo's however remotes::install_github() fails without it.
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      DCA_MODEL_INPUT_DOWNLOAD_URL: ${{ secrets.DCA_MODEL_INPUT_DOWNLOAD_URL }}
-      DCA_SYNAPSE_MASTER_FILEVIEW: ${{ secrets.DCA_SYNAPSE_MASTER_FILEVIEW }}
-
+      
     steps:
       - name: Install System Dependencies
         run: |
@@ -93,6 +91,12 @@ jobs:
             --service_repo 'Sage-Bionetworks/schematic' \
             --overwrite
 
+      - name: Write R environmental variables
+        shell: bash
+        run: |
+          echo Sys.setenv(DCA_MODEL_INPUT_DOWNLOAD_URL="${{ secrets.DCA_MODEL_INPUT_DOWNLOAD_URL }}") >> .Renviron
+          echo Sys.setenv(DCA_SYNAPSE_MASTER_FILEVIEW="${{ secrets.DCA_SYNAPSE_MASTER_FILEVIEW }}") >> .Renviron
+          
       - name: zip virtual env
         shell: bash
         # ShinyApps has a limit of 7000 files, far exceeded by the many Python dependencies
@@ -104,8 +108,6 @@ jobs:
       - name: Authorize and deploy app
         shell: Rscript {0}
         run: |
-          Sys.setenv(DCA_MODEL_INPUT_DOWNLOAD_URL="${{ secrets.DCA_MODEL_INPUT_DOWNLOAD_URL }}")
-          Sys.setenv(DCA_SYNAPSE_MASTER_FILEVIEW="${{ secrets.DCA_SYNAPSE_MASTER_FILEVIEW }}")
           # if there is a tag, 'refName' will be tag name
           repo <- Sys.getenv("GITHUB_REPOSITORY")
           appName <- strsplit(repo, "/")[[1]][2]

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -104,6 +104,8 @@ jobs:
       - name: Authorize and deploy app
         shell: Rscript {0}
         run: |
+          Sys.setenv(DCA_MODEL_INPUT_DOWNLOAD_URL="${{ secrets.DCA_MODEL_INPUT_DOWNLOAD_URL }}")
+          Sys.setenv(DCA_SYNAPSE_MASTER_FILEVIEW="${{ secrets.DCA_SYNAPSE_MASTER_FILEVIEW }}")
           # if there is a tag, 'refName' will be tag name
           repo <- Sys.getenv("GITHUB_REPOSITORY")
           appName <- strsplit(repo, "/")[[1]][2]

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -94,8 +94,8 @@ jobs:
       - name: Write R environmental variables
         shell: bash
         run: |
-          echo Sys.setenv(DCA_MODEL_INPUT_DOWNLOAD_URL="${{ secrets.DCA_MODEL_INPUT_DOWNLOAD_URL }}") >> .Renviron
-          echo Sys.setenv(DCA_SYNAPSE_MASTER_FILEVIEW="${{ secrets.DCA_SYNAPSE_MASTER_FILEVIEW }}") >> .Renviron
+          echo 'Sys.setenv(DCA_MODEL_INPUT_DOWNLOAD_URL="${{ secrets.DCA_MODEL_INPUT_DOWNLOAD_URL }}")' >> .Renviron
+          echo 'Sys.setenv(DCA_SYNAPSE_MASTER_FILEVIEW="${{ secrets.DCA_SYNAPSE_MASTER_FILEVIEW }}")' >> .Renviron
           
       - name: zip virtual env
         shell: bash

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -94,8 +94,8 @@ jobs:
       - name: Write R environmental variables
         shell: bash
         run: |
-          echo 'Sys.setenv(DCA_MODEL_INPUT_DOWNLOAD_URL="${{ secrets.DCA_MODEL_INPUT_DOWNLOAD_URL }}")' >> .Renviron
-          echo 'Sys.setenv(DCA_SYNAPSE_MASTER_FILEVIEW="${{ secrets.DCA_SYNAPSE_MASTER_FILEVIEW }}")' >> .Renviron
+          echo 'DCA_MODEL_INPUT_DOWNLOAD_URL="${{ secrets.DCA_MODEL_INPUT_DOWNLOAD_URL }}"' >> .Renviron
+          echo 'DCA_SYNAPSE_MASTER_FILEVIEW="${{ secrets.DCA_SYNAPSE_MASTER_FILEVIEW }}"' >> .Renviron
           
       - name: zip virtual env
         shell: bash

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -23,6 +23,8 @@ jobs:
     env:
       # This should not be necessary for installing from public repo's however remotes::install_github() fails without it.
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      DCA_MODEL_INPUT_DOWNLOAD_URL: ${{ secrets.DCA_MODEL_INPUT_DOWNLOAD_URL }}
+      DCA_SYNAPSE_MASTER_FILEVIEW: ${{ secrets.DCA_SYNAPSE_MASTER_FILEVIEW }}
 
     steps:
       - name: Install System Dependencies

--- a/functions/schematic_rest_api.R
+++ b/functions/schematic_rest_api.R
@@ -1,0 +1,270 @@
+#' @description Download an existing manifest
+#' @param url URI of API endpoint
+#' @param input_token Synapse PAT
+#' @param asset_view ID of view listing all project data assets
+#' @param dataset_id the parent ID of the manifest
+#' @param as_json if True return the manifest in JSON format
+#' @returns a csv of the manifest
+#' @export
+manifest_download <- function(url="http://localhost:3001/v1/manifest/download",
+                              input_token, asset_view, dataset_id, as_json=TRUE){
+  req <- httr::GET(url,
+                   query = list(
+                     asset_view = asset_view,
+                     dataset_id = dataset_id,
+                     as_json = as_json,
+                     input_token = input_token
+                   ))
+  manifest <- httr::content(req, as = "text")
+  jsonlite::fromJSON(manifest)
+}
+
+#' schematic rest api to generate manifest
+#'
+#' @param title Name of dataset 
+#' @param data_type Type of dataset 
+#' @param oauth true or false STRING passed to python
+#' @param use_annotations true or false STRING passed to python 
+#' @param dataset_id Synapse ID of existing manifest
+#' 
+#' @returns a URL to a google sheet
+#' @export
+manifest_generate <- function(url="http://localhost:3001/v1/manifest/generate",
+                              schema_url="https://raw.githubusercontent.com/ncihtan/data-models/main/HTAN.model.jsonld", #nolint
+                              title, data_type, oauth="true",
+                              use_annotations="false", dataset_id=NULL,
+                              asset_view, output_format) {
+  
+  req <- httr::GET(url,
+                   query = list(
+                     schema_url=schema_url,
+                     title=title,
+                     data_type=data_type,
+                     oauth=oauth,
+                     use_annotations=use_annotations,
+                     dataset_id=dataset_id,
+                     asset_view=asset_view,
+                     output_format=output_format
+                   ))
+  
+  manifest_url <- httr::content(req)
+  manifest_url
+}
+
+#' Populate a manifest sheet
+#' 
+#' @param url URL to schematic API endpoint
+#' @param schema_url URL to a schema jsonld 
+#' @param data_type Type of dataset
+#' @param title Title of csv
+#' @param csv_file Filepath of csv to validate
+#' @export
+manifest_populate <- function(url="http://localhost:3001/v1/manifest/populate",
+                              schema_url="https://raw.githubusercontent.com/ncihtan/data-models/main/HTAN.model.jsonld", #notlint
+                              data_type, title, return_excel=FALSE, csv_file) {
+  
+  req <- httr::POST(url,
+                    query=list(
+                      schema_url=schema_url,
+                      data_type=data_type,
+                      title=title,
+                      return_excel=return_excel),
+                    body=list(csv_file=httr::upload_file(csv_file, type = "text/csv"))
+  )
+  req
+  
+}
+
+
+#' schematic rest api to validate metadata
+#' 
+#' @param url URL to schematic API endpoint
+#' @param schema_url URL to a schema jsonld 
+#' @param data_type Type of dataset
+#' @param csv_file Filepath of csv to validate
+#' 
+#' @returns An empty list() if sucessfully validated. Or a list of errors.
+#' @export
+manifest_validate <- function(url="http://localhost:3001/v1/model/validate",
+                              schema_url="https://raw.githubusercontent.com/ncihtan/data-models/main/HTAN.model.jsonld", #nolint
+                              data_type, json_str) {
+  req <- httr::POST(url,
+                     query=list(
+                       schema_url=schema_url,
+                       data_type=data_type,
+                       json_str=json_str)
+                     #body=list(csv_file=httr::upload_file(csv_file))
+                    #body=list(file_name=file_name)
+  )
+  
+  if (httr::http_status(req)$category == "Server error") return(list(list(), list()))
+  annotation_status <- httr::content(req)
+  annotation_status
+}
+
+
+#' schematic rest api to submit metadata
+#' 
+#' @param url URL to schematic API endpoint
+#' @param schema_url URL to a schema jsonld 
+#' @param data_type Type of dataset
+#' @param dataset_id Synapse ID of existing manifest
+#' @param input_token Synapse login cookie, PAT, or API key.
+#' @param csv_file Filepath of csv to validate
+#' 
+#' @returns TRUE if successful upload or validate errors if not.
+#' @export
+model_submit <- function(url="http://localhost:3001/v1/model/submit",
+                         schema_url="https://raw.githubusercontent.com/ncihtan/data-models/main/HTAN.model.jsonld", #notlint
+                         data_type, dataset_id, restrict_rules=FALSE, input_token, json_str, asset_view) {
+  req <- httr::POST(url,
+                    #add_headers(Authorization=paste0("Bearer ", pat)),
+                    query=list(
+                      schema_url=schema_url,
+                      data_type=data_type,
+                      dataset_id=dataset_id,
+                      input_token=input_token,
+                      restrict_rules=restrict_rules,
+                      json_str=json_str,
+                      asset_view=asset_view),
+                    #body=list(file_name=httr::upload_file(file_name))
+                    #body=list(file_name=file_name)
+  )
+  
+  manifest_id <- httr::content(req)
+  manifest_id
+}
+
+#' Given a source model component (see https://w3id.org/biolink/vocab/category for definnition of component), return all components required by it.
+#' 
+#' @param schema_url Data Model URL
+#' @param source_component an attribute label indicating the source component. (i.e. Patient, Biospecimen, ScRNA-seqLevel1, ScRNA-seqLevel2)
+#' @param as_graph if False return component requirements as a list; if True return component requirements as a dependency graph (i.e. a DAG)
+#' 
+#' @returns A list of required components associated with the source component.
+#' @export
+model_component_requirements <- function(url="http://localhost:3001/v1/model/component-requirements",
+                                         schema_url, source_component,
+                                         as_graph = FALSE) {
+  
+  req <- httr::GET(url,
+                   query =  list(
+                     schema_url = schema_url,
+                     source_component = source_component,
+                     as_graph = as_graph
+                   ))
+  
+  if (httr::http_error(req)) stop(httr::http_status(req)$reason)
+  cont <- httr::content(req)
+  
+  if (inherits(cont, "xml_document")){
+    err_msg <- xml2::xml_text(xml2::xml_child(cont, "head/title"))
+    stop(sprintf("%s", err_msg))
+  }
+  
+  cont
+  
+}
+  
+
+#' Gets all datasets in folder under a given storage project that the current user has access to.
+#' 
+#' @param url URL to schematic API endpoint
+#' @param syn_master_file_view synapse ID of master file view.
+#' @param syn_master_file_name Synapse storage manifest file name.
+#' @param project_id synapse ID of a storage project.
+#' @param input_token synapse PAT
+#'
+#'@export
+storage_project_datasets <- function(url="http://localhost:3001/v1/storage/project/datasets",
+                                     asset_view,
+                                     project_id,
+                                     input_token) {
+  
+  req <- httr::GET(url,
+                    #add_headers(Authorization=paste0("Bearer ", pat)),
+                    query=list(
+                      asset_view=asset_view,
+                      project_id=project_id,
+                      input_token=input_token)
+  )
+  
+  httr::content(req)
+}
+
+#' Get all storage projects the current user has access to
+#' 
+#' @param url URL to schematic API endpoint
+#' @param syn_master_file_view synapse ID of master file view.
+#' @param syn_master_file_name Synapse storage manifest file name.
+#' @param input_token synapse PAT
+#'
+#' @export
+storage_projects <- function(url="http://localhost:3001/v1/storage/projects",
+                             asset_view,
+                             input_token) {
+  
+  req <- httr::GET(url,
+                   query = list(
+                     asset_view=asset_view,
+                     input_token=input_token
+                   ))
+  
+  httr::content(req)
+}
+
+#' /storage/dataset/files
+#'
+#' @param url URL to schematic API endpoint
+#' @param syn_master_file_view synapse ID of master file view.
+#' @param syn_master_file_name Synapse storage manifest file name.
+#' @param dataset_id synapse ID of a storage dataset.
+#' @param file_names a list of files with particular names (i.e. Sample_A.txt). If you leave it empty, it will return all dataset files under the dataset ID.
+#' @param full_path Boolean. If True return the full path as part of this filename; otherwise return just base filename
+#' @param input_token synapse PAT
+#'
+#' @export
+storage_dataset_files <- function(url="http://localhost:3001/v1/storage/dataset/files",
+                                  asset_view,
+                                  dataset_id, file_names=list(),
+                                  full_path=FALSE, input_token) {
+  
+  req <- httr::GET(url,
+                   #add_headers(Authorization=paste0("Bearer ", pat)),
+                   query=list(
+                     asset_view=asset_view,
+                     dataset_id=dataset_id,
+                     file_names=file_names,
+                     full_path=full_path,
+                     input_token=input_token))
+  httr::content(req)
+                   
+}
+
+#' /storage/asset/table
+#' 
+#' @param url URL to schematic API endpoint
+#' @param input_token synapse PAT
+#' @param asset_view Synapse ID of asset view
+#' @export
+get_asset_view_table <- function(url="http://localhost:3001/v1/storage/assets/tables",
+                                 input_token, asset_view, return_type="json") {
+  
+  req <- httr::GET(url,
+                   query=list(
+                     asset_view=asset_view,
+                     input_token=input_token,
+                     return_type=return_type))
+  
+  if (httr::http_status(req)$category == "Success") {
+    if (return_type=="json") {
+      return(list2DF(fromJSON(httr::content(req))))
+    } else {
+    csv <- readr::read_csv(httr::content(req))
+    return(csv)
+    }
+  } else stop("File could not be downloaded from Synapse.")
+  
+}
+
+

--- a/functions/schematic_rest_api.R
+++ b/functions/schematic_rest_api.R
@@ -33,7 +33,7 @@ manifest_generate <- function(url="http://localhost:3001/v1/manifest/generate",
                               schema_url="https://raw.githubusercontent.com/ncihtan/data-models/main/HTAN.model.jsonld", #nolint
                               title, data_type, oauth="true",
                               use_annotations="false", dataset_id=NULL,
-                              asset_view, output_format) {
+                              asset_view, output_format, input_token=NULL) {
   
   req <- httr::GET(url,
                    query = list(
@@ -44,7 +44,8 @@ manifest_generate <- function(url="http://localhost:3001/v1/manifest/generate",
                      use_annotations=use_annotations,
                      dataset_id=dataset_id,
                      asset_view=asset_view,
-                     output_format=output_format
+                     output_format=output_format,
+                     input_token=input_token
                    ))
   
   manifest_url <- httr::content(req)

--- a/functions/schematic_reticulate.R
+++ b/functions/schematic_reticulate.R
@@ -1,0 +1,100 @@
+setup_synapse_driver <- function(){
+  # old way
+  # library(reticulate)
+  # use_virtualenv(file.path(getwd(), ".venv"), required = TRUE)
+  # syn <- import("synapseclient")$Synapse()
+  # source_python("functions/metadataModel.py") # schemaGenerator object
+  # synapse_driver <- import("schematic.store.synapse")$SynapseStorage
+  
+  # new way
+  reticulate::use_virtualenv(file.path(getwd(), ".venv"), required = TRUE)
+  syn <- reticulate::import("synapseclient")$Synapse()
+  
+  MetadataModel <<- reticulate::import("schematic.models.metadata")$MetadataModel
+  CONFIG <<- reticulate::import("schematic")$CONFIG
+  SchemaGenerator <<- reticulate::import("schematic.schemas.generator")$SchemaGenerator
+  
+  config = CONFIG$load_config("schematic_config.yml")
+  
+  inputMModelLocation = config$model$input$location
+  inputMModelLocationType = config$model$input$file_type
+  
+  manifest_title = config$manifest$title
+  manifest_data_type = config$manifest$data_type[1]
+  
+  metadata_model <<- MetadataModel(inputMModelLocation, inputMModelLocationType)
+  
+  # create schema generator object for associateMetadataWithFiles
+  schema_generator <<- SchemaGenerator(inputMModelLocation)
+  
+  synapse_driver <<- reticulate::import("schematic.store.synapse")$SynapseStorage
+  
+}
+
+storage_projects_py <- function(synapse_driver, access_token) {
+  
+  tryCatch(
+    {
+      # get syn storage
+      syn_store <<- synapse_driver(access_token = access_token)
+      # get user's common projects
+      syn_store$getStorageProjects()
+    },
+    error = function(e) {
+      message(e$message)
+      return(NULL)
+    }
+  )
+}
+
+storage_projects_datasets_py <- function(synapse_driver, project_id) {
+  syn_store$getStorageDatasetsInProject(project_id) #%>% list2Vector()
+}
+
+storage_dataset_files_py <- function(project_id) {
+  file_list <- syn_store$getFilesInStorageDataset(project_id)
+}
+
+manifest_generate_py <- function(title, rootNode, filenames=NULL, datasetId){
+  metadata_model$getModelManifest(
+    title = title,
+    rootNode = rootNode,
+    filenames = filenames,
+    datasetId = datasetId
+  )
+}
+
+manifest_validate_py <- function(manifestPath, rootNode, restrict_rules=TRUE, project_scope){
+  tryCatch(
+    metadata_model$validateModelManifest(
+      manifestPath = manifestPath,
+      rootNode = rootNode,
+      restrict_rules = TRUE, # set true to disable great expectation
+      project_scope = project_scope
+    ),
+    error = function(e) {
+      message("'validateModelManifest' failed:\n", e$message)
+      return(NULL)
+    }
+  )
+}
+
+manifest_populate_py <- function(title, manifestPath, rootNode) {
+  metadata_model$populateModelManifest(
+    title = title,
+    manifestPath = manifestPath,
+    rootNode = rootNode
+  )
+}
+
+model_submit_py <- function(SchemaGenerator, metadataManifestPath, datasetId, manifest_record_type="table", restrict_manifest=FALSE) {
+  syn_store$associateMetadataWithFiles(
+    schemaGenerator = SchemaGenerator,
+    metadataManifestPath = metadataManifestPath,
+    datasetId = datasetId,
+    manifest_record_type = manifest_record_type,
+    restrict_manifest = restrict_manifest
+  )
+}
+
+synase_user_profile_py <- function() syn$getUserProfile()$userName

--- a/functions/schematic_reticulate.R
+++ b/functions/schematic_reticulate.R
@@ -8,7 +8,7 @@ setup_synapse_driver <- function(){
   
   # new way
   reticulate::use_virtualenv(file.path(getwd(), ".venv"), required = TRUE)
-  syn <- reticulate::import("synapseclient")$Synapse()
+  syn <<- reticulate::import("synapseclient")$Synapse()
   
   MetadataModel <<- reticulate::import("schematic.models.metadata")$MetadataModel
   CONFIG <<- reticulate::import("schematic")$CONFIG

--- a/functions/schematic_reticulate.R
+++ b/functions/schematic_reticulate.R
@@ -97,4 +97,4 @@ model_submit_py <- function(SchemaGenerator, metadataManifestPath, datasetId, ma
   )
 }
 
-synase_user_profile_py <- function() syn$getUserProfile()$userName
+synapse_user_profile_py <- function() syn$getUserProfile()$userName

--- a/functions/synapse_rest_api.R
+++ b/functions/synapse_rest_api.R
@@ -1,0 +1,101 @@
+#' @title Get Synapse user profile info
+#' @details
+#' For information on authenticating synapse REST API queries
+#' https://docs.synapse.org/rest/#org.sagebionetworks.auth.controller.AuthenticationController
+#' Authentication to Synapse services requires an access token passed in the
+#' HTTP Authorization header, as per the HTTP bearer authorization standard. 
+#' https://datatracker.ietf.org/doc/html/rfc6750#section-2.1
+#' https://docs.synapse.org/rest/#org.sagebionetworks.repo.web.controller.UserProfileController
+#' PAT is the synapse personal access token OR the browser cookie from a logged-in session.
+#' 
+#' @param url Synapse REST API url for userProfile
+#' @param auth Synapse PAT or authorization token
+#' 
+#' @export
+synapse_user_profile <- function(
+  url="https://repo-prod.prod.sagebase.org/repo/v1/userProfile", auth=NULL) {
+  req <- httr::GET(url, httr::add_headers(Authorization=paste0("Bearer ", auth)))
+  httr::content(req)
+}
+
+#' @title Is a Synapse user certified?
+#' @details
+#' https://rest-docs.synapse.org/rest/GET/user/id/certifiedUserPassingRecord.html
+#' Based on python client https://github.com/Sage-Bionetworks/synapsePythonClient/blob/3da21b9e2542c7da8cdab9925926737fe2162a54/synapseclient/client.py#L606
+#' 
+#' @param url URL to Synapse REST API for certification
+#' @param endpoint The Synapse API endpoint
+#' @param auth Synapse PAT or authorization token
+#'
+#' @export
+synapse_is_certified <- function(url="https://repo-prod.prod.sagebase.org/repo/v1/user",
+                                 endpoint="certifiedUserPassingRecord",
+                                 auth=NULL) {
+  
+  # Get user profile and ownerId
+  user_profile <- synapse_user_profile(auth=auth)
+  if (!"ownerId" %in% names(user_profile)) return(FALSE)
+  ownerid <- user_profile[["ownerId"]]
+  url_req <- file.path(url, ownerid, endpoint)
+  req <- httr::GET(url_req)
+  httr::content(req)[["passed"]]
+  
+}
+
+
+#content(GET(sprintf("https://repo-prod.prod.sagebase.org/repo/v1/user/%s/certifiedUserPassingRecord", "3438856")))
+#https://repo-prod.prod.sagebase.org/repo/v1/user
+
+#' @title GET Synapse Entity
+#' @description Wrapper for https://rest-docs.synapse.org/rest/GET/entity/id.html
+#' 
+#' @param url URL of synapse REST API GET table entity endpoint
+#' @param id ID of synapse table
+#' @param auth Synapse PAT
+#' 
+#' @export
+synapse_get <- function(url = "https://repo-prod.prod.sagebase.org/repo/v1/entity/",
+                        id, auth) {
+  
+  if (is.null(id)) stop("id cannot be NULL")
+  req_url <- file.path(url, id)
+  req <- httr::GET(req_url,
+             httr::add_headers(Authorization=paste0("Bearer ", auth)))
+  
+  # Send error if unsuccessful query
+  status <- httr::http_status(req)
+  if (status$category != "Success") stop(status$message)
+  
+  cont <- httr::content(req)
+  dplyr::bind_rows(cont)
+  
+}
+
+
+#' @title Check Access Permissions to a Synapse Entity
+#' @description wrapper for https://rest-docs.synapse.org/rest/GET/entity/id/access.html
+#' 
+#' @param url URL to REST API endpoint
+#' @param id Synapse ID
+#' @param access Access Type to check
+#' @param auth Synapse authentication token
+#'
+#' @export
+synapse_access <- function(url = "https://repo-prod.prod.sagebase.org/repo/v1/entity",
+                        id, access, auth) {
+  
+  if (is.null(id)) stop("id cannot be NULL")
+  req_url <- file.path(url, id, "access")
+  req <- httr::GET(req_url,
+                   httr::add_headers(Authorization=paste0("Bearer ", auth)),
+                   query = list(accessType=access))
+  
+  # Send error if unsuccessful query
+  status <- httr::http_status(req)
+  if (status$category != "Success") stop(status$message)
+  
+  cont <- httr::content(req)
+  cont$result
+  
+}
+

--- a/global.R
+++ b/global.R
@@ -95,6 +95,18 @@ api <- oauth_endpoint(
 # The 'openid' scope is required by the protocol for retrieving user information.
 scope <- "openid view download modify"
 
+# parse environment variables for configuration
+parse_env_var <- function(x, el_delim=",", kv_delim=":"){
+  # assume string of key-value pairs
+  elements <- stringr::str_split(x, el_delim, simplify = TRUE)
+  unlist(lapply(elements, function(y){
+    kv <- stringr::str_split(y, kv_delim, n=2)
+    setNames(kv[[1]][[2]], kv[[1]][[1]])
+  }))
+}
+
+all_asset_views <- parse_env_var(Sys.getenv("DCA_SYNAPSE_MASTER_FILEVIEW"))
+
 # import R files
 source_files <- list.files(c("functions", "modules"), pattern = "*\\.R$", recursive = TRUE, full.names = TRUE) %>%
   .[!grepl("dashboard", .)]
@@ -112,7 +124,7 @@ if (dca_schematic_api == "reticulate"){
   system("chmod -R +x .venv")
   # Don't necessarily have to set `RETICULATE_PYTHON` env variable
   Sys.unsetenv("RETICULATE_PYTHON")
-  setup_synapse_driver()
+  #setup_synapse_driver()
   
   ## Read config.json
   if (!file.exists("www/config.json")) {

--- a/global.R
+++ b/global.R
@@ -129,9 +129,9 @@ if (dca_schematic_api == "reticulate"){
   
   ## Read config.json
   if (!file.exists("www/config.json")) {
-    system(
-      "python3 .github/config_schema.py -c schematic_config.yml --service_repo 'Sage-Bionetworks/schematic' --overwrite"
-    )
+#    system(
+#      "python3 .github/config_schema.py -c schematic_config.yml --service_repo 'Sage-Bionetworks/schematic' --overwrite"
+#    )
   }
 }
 config_file <- fromJSON("www/config.json")

--- a/global.R
+++ b/global.R
@@ -40,7 +40,10 @@ schematic_config <- yaml.load_file("schematic_config.yml")
 dca_schematic_api <- schematic_config$api$type
 asset_view <- schematic_config$synapse$master_fileview
 data_model <- schematic_config$model$input$download_url
-api_uri <- paste(schematic_config$api$host, schematic_config$api$port, sep=":")
+api_uri <- ifelse(is.null(schematic_config$ap$port),
+  schematic_config$api$host,
+  paste(schematic_config$api$host, schematic_config$api$port, sep=":")
+)
 
 # update port if running app locally
 if (interactive()) {

--- a/global.R
+++ b/global.R
@@ -40,10 +40,11 @@ schematic_config <- yaml.load_file("schematic_config.yml")
 dca_schematic_api <- schematic_config$api$type
 asset_view <- schematic_config$synapse$master_fileview
 data_model <- schematic_config$model$input$download_url
-api_uri <- ifelse(is.null(schematic_config$ap$port),
-  schematic_config$api$host,
-  paste(schematic_config$api$host, schematic_config$api$port, sep=":")
-)
+if (schematic_config$api$type == "rest") {
+  api_uri <- ifelse(is.null(schematic_config$ap$port),
+               schematic_config$api$host,
+               paste(schematic_config$api$host, schematic_config$api$port, sep=":")
+)}
 
 # update port if running app locally
 if (interactive()) {

--- a/install-pkgs.R
+++ b/install-pkgs.R
@@ -25,7 +25,8 @@ cran <- c(
   "igraph==1.2.11",
   "networkD3==0.4",
   "data.tree==1.0.0",
-  "r2d3==0.2.6"
+  "r2d3==0.2.6",
+  "xml2"
 )
 gh <- c(
   "dreamRs/shinypop",

--- a/schematic_config.yml
+++ b/schematic_config.yml
@@ -1,38 +1,28 @@
-# Do not change the 'definitions' section unless you know what you're doing
 schematic:
-  branch: 'empty'
-  sha: 'empty'
-  release_version: 'empty'
-
+  branch: empty
+  sha: empty
+  release_version: empty
 definitions:
-  synapse_config: '.synapseConfig'
-  creds_path: 'credentials.json'
-  token_pickle: 'token.pickle'
-  service_acct_creds: 'schematic_service_account_creds.json'
-
+  synapse_config: .synapseConfig
+  creds_path: credentials.json
+  token_pickle: token.pickle
+  service_acct_creds: schematic_service_account_creds.json
 synapse:
-  master_fileview: 'syn33715412'
-  manifest_folder: 'manifests'
-  manifest_basename: 'synapse_storage_manifest'
-  token_creds: 'syn23643259'
-  service_acct_creds: 'syn25171627'
-
+  master_fileview: syn33715412
+  manifest_folder: manifests
+  manifest_basename: synapse_storage_manifest
+  token_creds: syn23643259
+  service_acct_creds: syn25171627
 manifest:
-  # if making many manifests, just include name prefix
-  title: 'example'
-  # to make all manifests enter only 'all manifests'
+  title: example
   data_type:
-    - 'Biospecimen'
-    - 'Patient'
-
+  - Biospecimen
+  - Patient
 model:
   input:
-    # if both 'download_url' and 'repo' present, `repo` will be used
-    download_url: 'https://raw.githubusercontent.com/Sage-Bionetworks/data-models/main/example.model.jsonld' # url to download JSON-LD data model
-    repo: 'Sage-Bionetworks/data-models' # data model repo url (<repo-owner>/<repo-name>/<version/branch>), version or branch is optional
-    location: 'data-models/example.model.jsonld' # path to JSON-LD file
-    file_type: 'local'
-
+    download_url: https://raw.githubusercontent.com/Sage-Bionetworks/data-models/main/example.model.jsonld
+    location: data-models/example.model.jsonld
+    file_type: local
 style:
   google_manifest:
     req_bg_color:
@@ -43,10 +33,7 @@ style:
       red: 1.0
       green: 1.0
       blue: 0.9019
-    master_template_id: '1LYS5qE4nV9jzcYw5sXwCza25slDfRA1CIg3cs-hCdpU'
-    strict_validation: true
-
+    master_template_id: 1LYS5qE4nV9jzcYw5sXwCza25slDfRA1CIg3cs-hCdpU
+    strict_validation: yes
 api:
-  type: 'reticulate'
-  host: "https://schematic.dnt-dev.sagebase.org"
-  #port: "3001"
+  type: reticulate

--- a/schematic_config.yml
+++ b/schematic_config.yml
@@ -36,4 +36,4 @@ style:
     master_template_id: 1LYS5qE4nV9jzcYw5sXwCza25slDfRA1CIg3cs-hCdpU
     strict_validation: yes
 api:
-  type: rest
+  type: reticulate

--- a/schematic_config.yml
+++ b/schematic_config.yml
@@ -45,3 +45,8 @@ style:
       blue: 0.9019
     master_template_id: '1LYS5qE4nV9jzcYw5sXwCza25slDfRA1CIg3cs-hCdpU'
     strict_validation: true
+
+api:
+  type: 'rest'
+  host: "https://schematic.dnt-dev.sagebase.org"
+  #port: "3001"

--- a/schematic_config.yml
+++ b/schematic_config.yml
@@ -47,6 +47,6 @@ style:
     strict_validation: true
 
 api:
-  type: 'rest'
+  type: 'reticulate'
   host: "https://schematic.dnt-dev.sagebase.org"
   #port: "3001"

--- a/schematic_config.yml
+++ b/schematic_config.yml
@@ -8,7 +8,7 @@ definitions:
   token_pickle: token.pickle
   service_acct_creds: schematic_service_account_creds.json
 synapse:
-  master_fileview: syn33715412
+  master_fileview: syn27210848
   manifest_folder: manifests
   manifest_basename: synapse_storage_manifest
   token_creds: syn23643259
@@ -20,7 +20,7 @@ manifest:
   - Patient
 model:
   input:
-    download_url: https://raw.githubusercontent.com/Sage-Bionetworks/data-models/main/example.model.jsonld
+    download_url: https://raw.githubusercontent.com/mc2-center/data-models/main/mc2.model.jsonld
     location: data-models/example.model.jsonld
     file_type: local
 style:
@@ -36,4 +36,4 @@ style:
     master_template_id: 1LYS5qE4nV9jzcYw5sXwCza25slDfRA1CIg3cs-hCdpU
     strict_validation: yes
 api:
-  type: reticulate
+  type: rest

--- a/server.R
+++ b/server.R
@@ -95,9 +95,10 @@ shinyServer(function(input, output, session) {
     
     user_name <- synapse_user_profile(auth=access_token)$userName
 
-    is_certified <- switch(dca_schematic_api,
-                           reticulate = syn$is_certified(user_name),
-                           rest = synapse_is_certified(auth=access_token))
+    is_certified <- synapse_is_certified(auth=access_token)
+    # is_certified <- switch(dca_schematic_api,
+    #                        reticulate = syn$is_certified(user_name),
+    #                        rest = synapse_is_certified(auth=access_token))
     if (!is_certified) {
       dcWaiter("update", landing = TRUE, isCertified = FALSE)
     } else {

--- a/server.R
+++ b/server.R
@@ -36,6 +36,8 @@ shinyServer(function(input, output, session) {
 
   # data available to the user
   syn_store <- NULL # gets list of projects they have access to
+  
+  asset_views <- reactiveVal(c("mock dca fileview (syn33715412)"="syn33715412"))
 
   data_list <- list(
     projects = reactiveVal(NULL), folders = reactiveVal(NULL),
@@ -78,6 +80,14 @@ shinyServer(function(input, output, session) {
     # Shiny app'
     #
     access_token <- session$userData$access_token
+    
+    has_access <- vapply(all_asset_views, function(x) {
+      synapse_access(id=x, access="DOWNLOAD", auth=access_token)
+    }, 1L)
+    asset_views(all_asset_views[has_access==1])
+    if (length(asset_views) == 0) stop("You do not have DOWNLOAD access to any supported Asset Views.")
+    updateSelectInput(session, "dropdown_asset_view",
+                      choices = asset_views())
     
     if (dca_schematic_api == "reticulate") {
       syn$login(authToken = access_token, rememberMe = FALSE)

--- a/server.R
+++ b/server.R
@@ -296,7 +296,8 @@ shinyServer(function(input, output, session) {
                                                     data_type = selected$schema(),
                                                     dataset_id = selected$folder(),
                                                     asset_view = asset_view,
-                                                    output_format = "google_sheet")
+                                                    output_format = "google_sheet",
+                                                    input_token=access_token)
                            )
 
     # generate link
@@ -387,14 +388,13 @@ shinyServer(function(input, output, session) {
   observeEvent(input$btn_val_gsheet, {
     # loading screen for Google link generation
     dcWaiter("show", msg = "Generating link...")
-    
     filled_manifest <- switch(dca_schematic_api,
                               reticulate = manifest_populate_py(paste0(config$community, " ", input$dropdown_datatype),
                                                                 inFile$raw()$datapath,
                                                                 selected$schema()),
                               rest = manifest_populate(url=file.path(api_uri, "v1/manifest/populate"),
                                                        schema_url = data_model,
-                                                       title = "Test Populate Patient - REST API",
+                                                       title = paste0(config$community, " ", input$dropdown_datatype),
                                                        data_type = selected$schema(),
                                                        return_excel = FALSE,
                                                        csv_file = inFile$raw()$datapath))

--- a/server.R
+++ b/server.R
@@ -139,7 +139,7 @@ shinyServer(function(input, output, session) {
                                                     input_token = access_token)
     )
     data_list$projects(list2Vector(data_list_raw))
-    
+
     if (is.null(data_list$projects()) || length(data_list$projects()) == 0) {
       dcWaiter("update", landing = TRUE, isPermission = FALSE)
     } else {
@@ -272,7 +272,6 @@ shinyServer(function(input, output, session) {
   # validate before generating template
   observeEvent(c(selected$folder(), selected$schema(), input$tabs), {
     req(input$tabs %in% c("tab_template", "tab_validate"))
-
     warn_text <- NULL
 
     if (length(data_list$folder()) == 0) {
@@ -290,7 +289,7 @@ shinyServer(function(input, output, session) {
       file_list <- switch(dca_schematic_api,
                           reticulate = storage_dataset_files_py(selected$folder()),
                           rest = storage_dataset_files(url=file.path(api_uri, "v1/storage/dataset/files"),
-                                                                  asset_view = asset_view,
+                                                                  asset_view = selected$master_asset_view(),
                                                                   dataset_id = selected$folder(),
                                                                   input_token=access_token))
 
@@ -333,7 +332,7 @@ shinyServer(function(input, output, session) {
                                                     title = paste0(config$community, " ", input$dropdown_datatype),
                                                     data_type = selected$schema(),
                                                     dataset_id = selected$folder(),
-                                                    asset_view = asset_view,
+                                                    asset_view = selected$master_asset_view(),
                                                     output_format = "google_sheet",
                                                     input_token=access_token)
                            )
@@ -484,7 +483,7 @@ shinyServer(function(input, output, session) {
         file_list_raw <- switch(dca_schematic_api,
                             reticulate = storage_dataset_files_py(selected$folder()),
                             rest = storage_dataset_files(url=file.path(api_uri, "v1/storage/dataset/files"),
-                                                         asset_view = asset_view,
+                                                         asset_view = selected$master_asset_view(),
                                                          dataset_id = selected$folder(),
                                                          input_token=access_token))
         data_list$files(list2Vector(file_list_raw))
@@ -516,7 +515,7 @@ shinyServer(function(input, output, session) {
                                                              input_token = access_token,
                                                              restrict_rules = FALSE,
                                                              json_str = jsonlite::toJSON(read_csv(tmp_file_path)),
-                                                             asset_view = asset_view)
+                                                             asset_view = selected$master_asset_view())
                             )
       manifest_path <- tags$a(href = paste0("https://www.synapse.org/#!Synapse:", manifest_id), manifest_id, target = "_blank")
 
@@ -560,7 +559,7 @@ shinyServer(function(input, output, session) {
                                                 input_token = access_token,
                                                 restrict_rules = FALSE,
                                                 json_str = jsonlite::toJSON(read_csv(tmp_file_path)),
-                                                asset_view = asset_view)
+                                                asset_view = selected$master_asset_view())
       )
       manifest_path <- tags$a(href = paste0("https://www.synapse.org/#!Synapse:", manifest_id), manifest_id, target = "_blank")
 

--- a/server.R
+++ b/server.R
@@ -106,7 +106,7 @@ shinyServer(function(input, output, session) {
 
       user_name <- switch(dca_schematic_api,
                           reticulate = synapse_user_profile_py(),
-                          rest = synapse_user_profile(auth=Sys.getenv("SYNAPSE_PAT"))$userName
+                          rest = synapse_user_profile(auth=access_token)$userName
       )
 
       is_certified <- switch(dca_schematic_api,

--- a/server.R
+++ b/server.R
@@ -117,8 +117,8 @@ shinyServer(function(input, output, session) {
       schematic_config$synapse$master_fileview <- selected$master_asset_view()
       schematic_config$model$input$download_url <- model_ops[names(model_ops) == selected$master_asset_view()]
       yaml::write_yaml(schematic_config, "schematic_config.yml")
-      syn$login(authToken = access_token, rememberMe = FALSE)
       setup_synapse_driver()
+      syn$login(authToken = access_token, rememberMe = FALSE)
       
       system(
         "python3 .github/config_schema.py -c schematic_config.yml --service_repo 'Sage-Bionetworks/schematic' --overwrite"

--- a/ui.R
+++ b/ui.R
@@ -184,7 +184,7 @@ ui <- shinydashboardPlus::dashboardPage(
         tabName = "tab_template",
         useShinyjs(),
         h2("Download Template for Selected Folder"),
-        if (Sys.getenv("DCA_MANIFEST_OUTPUT_FORMAT") != "excel") {
+        #if (Sys.getenv("DCA_MANIFEST_OUTPUT_FORMAT") != "excel") {
         fluidRow(
           box(
             title = "Get Link, Annotate, and Download Template as CSV",
@@ -207,28 +207,28 @@ ui <- shinydashboardPlus::dashboardPage(
             ),
             helpText("This link will leads to an empty template or your previously submitted template with new files if applicable.")
           )
-        )}else{
-        fluidRow(
-          box(
-            title = "Or download data as an Excel sheet",
-            status = "primary",
-            width = 12,
-            downloadButton("downloadData", "Download Excel Spreadsheet."),
-            hidden(
-              div(
-                id = "div_template_warn_xls",
-                height = "100%",
-                htmlOutput("text_template_warn_xls")
-              ),
-              div(
-                id = "div_template_xls",
-                height = "100%",
-                htmlOutput("text_template_xls")
-              )
-            ),
-            helpText("This link will leads to an empty template or your previously submitted template with new files if applicable.")
-          )
-        )},
+        ),#}else{
+        # fluidRow(
+        #   box(
+        #     title = "Or download data as an Excel sheet",
+        #     status = "primary",
+        #     width = 12,
+        #     downloadButton("downloadData", "Download Excel Spreadsheet."),
+        #     hidden(
+        #       div(
+        #         id = "div_template_warn_xls",
+        #         height = "100%",
+        #         htmlOutput("text_template_warn_xls")
+        #       ),
+        #       div(
+        #         id = "div_template_xls",
+        #         height = "100%",
+        #         htmlOutput("text_template_xls")
+        #       )
+        #     ),
+        #     helpText("This link will leads to an empty template or your previously submitted template with new files if applicable.")
+        #   )
+        # )},
         switchTabUI("switchTab3", direction = "both")
       ),
       # Fourth tab content

--- a/ui.R
+++ b/ui.R
@@ -97,7 +97,7 @@ ui <- shinydashboardPlus::dashboardPage(
     # load dependencies
     use_notiflix_report(width = "400px"),
     use_waiter(),
-    dcamodules::use_dca(),
+    #dcamodules::use_dca(),
     tabItems(
       # First tab content
       # tabItem(

--- a/ui.R
+++ b/ui.R
@@ -132,22 +132,12 @@ ui <- shinydashboardPlus::dashboardPage(
             title = "Select a DCC: ",
             selectInput(
               inputId = "dropdown_asset_view",
-              label = NULL, #"Asset View:",
-              choices = parse_env_var(Sys.getenv("DCA_SYNAPSE_MASTER_FILEVIEW"))#"Generating..."
+              label = NULL, 
+              choices = all_asset_views)
             ),
             actionButton("btn_asset_view", "Click to confirm",
                          class = "btn-primary-color"
             )
-          )
-          ,
-          # box(
-          #   #title = "Confirm choice",
-          #   status = "primary",
-          #   width = 6,
-          #   actionButton("btn_asset_view", "Click to confirm",
-          #                class = "btn-primary-color"
-          #                )
-          # )
         )#,
         #switchTabUI("switchTab1", direction = "right") # remove arrow from assetview page.
       ),

--- a/ui.R
+++ b/ui.R
@@ -170,7 +170,7 @@ ui <- shinydashboardPlus::dashboardPage(
             width = 6,
             title = "Choose a Data Type: ",
             selectInput(
-              inputId = "dropdown_template",
+              inputId = "dropdown_datatype",
               label = "Data Type Template:",
               choices = "Generating..."
             )


### PR DESCRIPTION
Adds the ability for DCA to use schematic through python or its REST API. For each schematic endpoint that DCA uses, a pair of functions are added, one via reticulate and the other via the REST API. The DCA app code uses `switch()` to use schematic through the desired api. The user sets the option `api$type` to either 'reticulate' or 'rest' to determine which functionality DCA will access.

This also adds a DCC selection screen. There are environment variables set to specify the available asset views and data model URLs. After selecting a DCC, when using reticulate, DCA will overwrite `schematic_config.yml` and `www/config.json`.