### PR TITLE
Dev skip download

### DIFF
--- a/server.R
+++ b/server.R
@@ -448,6 +448,14 @@ shinyServer(function(input, output, session) {
   
   })
   
+  observeEvent(input$btn_folder_have_template, {
+    selected_folder <- data_list$folders()[which(data_list$folders() == input$dropdown_folder)]
+    selected$folder(selected_folder)
+    # clean tags in generating-template tab
+    updateTabsetPanel(session, "tabs",
+                      selected = "tab_upload")
+  })
+  
   observeEvent(input$update_confirm, {
     req(input$update_confirm == TRUE)
     isUpdateFolder(TRUE)

--- a/ui.R
+++ b/ui.R
@@ -143,9 +143,13 @@ ui <- shinydashboardPlus::dashboardPage(
         label = NULL,
         choices = "Generating..."
       ),
-        actionButton("btn_folder", "Go",
+        actionButton("btn_folder", "Download template",
           class = "btn-primary-color"
-        )
+        ),
+      actionButton("btn_folder_have_template",
+                   "I already have a template or manifest",
+                   class = "btn-primary-color"
+      )
       )
     )
   ),


### PR DESCRIPTION
Add a button after selecting a folder to skip ahead to validation instead of automatically downloading a manifest.