### PR TITLE
Dev sprint 11 UI updates

### DIFF
--- a/server.R
+++ b/server.R
@@ -380,14 +380,10 @@ shinyServer(function(input, output, session) {
     updateTabsetPanel(session, "tabs",
     selected = "tab_template")
     
-    selected_folder <- data_list$folders()[which(data_list$folders() == input$dropdown_folder)]
     output$template_title <- renderText({ sprintf("Get %s template for %s",
       selected$schema(),
-      names(selected_folder))
+      names(selected$folder()))
     })
-    selected$folder(selected_folder)
-    updateSelectInput(session, "header_dropdown_folder",
-                      choices = selected$folder())
     # clean tags in generating-template tab
     sapply(clean_tags[1:2], FUN = hide)
     
@@ -423,6 +419,10 @@ shinyServer(function(input, output, session) {
   
   observeEvent(input$dropdown_folder,{
     shinyjs::enable("btn_folder")
+    selected_folder <- data_list$folders()[which(data_list$folders() == input$dropdown_folder)]
+    selected$folder(selected_folder)
+    updateSelectInput(session, "header_dropdown_folder",
+                      choices = selected$folder())
   })
   
   observeEvent(data_list$files(), ignoreInit = TRUE, {
@@ -459,8 +459,6 @@ shinyServer(function(input, output, session) {
   })
   
   observeEvent(input$btn_folder_have_template, {
-    selected_folder <- data_list$folders()[which(data_list$folders() == input$dropdown_folder)]
-    selected$folder(selected_folder)
     shinyjs::show(select = "li:nth-child(5)")
     shinyjs::show(select = "li:nth-child(6)")
     updateTabsetPanel(session, "tabs",

--- a/server.R
+++ b/server.R
@@ -522,6 +522,7 @@ shinyServer(function(input, output, session) {
     file.path(api_uri, "v1/manifest/generate"),
     NA)
     .output_format <- dcc_config_react()$manifest_output_format
+    .use_annotations <- dcc_config_react()$manifest_use_annotations
     
     promises::future_promise({
       switch(dca_schematic_api, 
@@ -532,7 +533,7 @@ shinyServer(function(input, output, session) {
           data_type = .schema,
           dataset_id = .datasetId,
           asset_view = .asset_view,
-          use_annotations = FALSE,
+          use_annotations = .use_annotations,
           output_format = .output_format,
           access_token=access_token
         ),

--- a/server.R
+++ b/server.R
@@ -461,7 +461,8 @@ shinyServer(function(input, output, session) {
   observeEvent(input$btn_folder_have_template, {
     selected_folder <- data_list$folders()[which(data_list$folders() == input$dropdown_folder)]
     selected$folder(selected_folder)
-    # clean tags in generating-template tab
+    shinyjs::show(select = "li:nth-child(5)")
+    shinyjs::show(select = "li:nth-child(6)")
     updateTabsetPanel(session, "tabs",
                       selected = "tab_upload")
   })
@@ -765,7 +766,7 @@ shinyServer(function(input, output, session) {
     # If a file-based component selected (define file-based components) note for future
     # the type to filter (eg file-based) on could probably also be a config choice
     display_names <- config_schema()$manifest_schemas$display_name[config_schema()$manifest_schemas$type == "file"]
-    
+
     if (input$dropdown_template %in% display_names) {
       # make into a csv or table for file-based components already has entityId
       if ("entityId" %in% colnames(submit_data)) {

--- a/server.R
+++ b/server.R
@@ -144,6 +144,10 @@ shinyServer(function(input, output, session) {
       choices = c("Offline mock data (synXXXXXX)"="synXXXXXX"))
     dcWaiter("hide")
   }
+    
+  if (length(asset_views()) == 1L) {
+    click("btn_asset_view")
+  } 
   
   ######## Arrow Button ########
   lapply(1:6, function(i) {

--- a/server.R
+++ b/server.R
@@ -458,6 +458,14 @@ shinyServer(function(input, output, session) {
   
   })
   
+  observeEvent(input$btn_folder_have_template, {
+    selected_folder <- data_list$folders()[which(data_list$folders() == input$dropdown_folder)]
+    selected$folder(selected_folder)
+    # clean tags in generating-template tab
+    updateTabsetPanel(session, "tabs",
+                      selected = "tab_upload")
+  })
+  
   observeEvent(input$update_confirm, {
     req(input$update_confirm == TRUE)
     isUpdateFolder(TRUE)

--- a/server.R
+++ b/server.R
@@ -515,6 +515,11 @@ shinyServer(function(input, output, session) {
     shinyjs::addClass(id = "header_selection_dropdown", class = "dropdown open")
   })
   
+  observeEvent(input$tabs, {
+    req(input$tabs == "tab_template_select")
+    shinyjs::show("header_selection_dropdown")
+  })
+  
   observeEvent(c(input$`switchTab4-Next`, input$tabs), {
   
     req(input$tabs == "tab_template")

--- a/server.R
+++ b/server.R
@@ -512,6 +512,11 @@ shinyServer(function(input, output, session) {
   
   })
   
+  observeEvent(input$tabs, {
+    req(input$tabs %in% c("tab_project", "tab_template_select", "tab_folder", "tab_template", "tab_upload"))
+    shinyjs::addClass(id = "header_selection_dropdown", class = "dropdown open")
+  })
+  
   observeEvent(c(input$`switchTab4-Next`, input$tabs), {
   
     req(input$tabs == "tab_template")

--- a/server.R
+++ b/server.R
@@ -342,6 +342,8 @@ shinyServer(function(input, output, session) {
     updateTabsetPanel(session, "tabs",
       selected = "tab_template_select")
     shinyjs::show(select = "li:nth-child(3)")
+    updateSelectInput(session, "header_dropdown_project",
+      choices = selected$project())
     dcWaiter("hide")
   })
   
@@ -357,6 +359,8 @@ shinyServer(function(input, output, session) {
     selected$schema(data_list$template()[input$dropdown_template])
     updateSelectInput(session, "dropdown_folder", choices = data_list$folders())
     updateTabsetPanel(session, "tabs", selected = "tab_folder")
+    updateSelectInput(session, "header_dropdown_template",
+                      choices = selected$schema())
     shinyjs::show(select = "li:nth-child(4)")
     dcWaiter("hide")
   })
@@ -382,6 +386,8 @@ shinyServer(function(input, output, session) {
       names(selected_folder))
     })
     selected$folder(selected_folder)
+    updateSelectInput(session, "header_dropdown_folder",
+                      choices = selected$folder())
     # clean tags in generating-template tab
     sapply(clean_tags[1:2], FUN = hide)
     

--- a/ui.R
+++ b/ui.R
@@ -18,7 +18,8 @@ ui <- shinydashboardPlus::dashboardPage(
       span(class = "logo-mini", "DCA")
     ),
     uiOutput("logo"),
-    leftUi = tagList(
+    leftUi = hidden(
+      tagList(
       dropdownBlock(
         id = "header_selection_dropdown",
         title = "Selected data",
@@ -52,6 +53,7 @@ ui <- shinydashboardPlus::dashboardPage(
         )
       )
     )
+    ) # end hidden
   ),
   dashboardSidebar(
     width = 250,

--- a/ui.R
+++ b/ui.R
@@ -21,9 +21,9 @@ ui <- shinydashboardPlus::dashboardPage(
     leftUi = tagList(
       dropdownBlock(
         id = "header_selection_dropdown",
-        title = "Selection",
+        title = "Selected data",
         icon = icon("sliders"),
-        badgeStatus = "info",
+        badgeStatus = NULL,
         fluidRow(
           div(
             id = "header_content_project",

--- a/ui.R
+++ b/ui.R
@@ -57,6 +57,7 @@ ui <- shinydashboardPlus::dashboardPage(
   ),
   dashboardSidebar(
     width = 250,
+    hidden(
     sidebarMenu(
       id = "tabs",
       menuItem(
@@ -94,6 +95,7 @@ ui <- shinydashboardPlus::dashboardPage(
         id = "sidebar_footer", `data-toggle` = "tab",
         tags$footer(HTML(' Powered by <i class="far fa-heart"></i> and Sage Bionetworks'))
       )
+    )
     )
   ),
   dashboardBody(

--- a/ui.R
+++ b/ui.R
@@ -177,9 +177,13 @@ ui <- shinydashboardPlus::dashboardPage(
         label = NULL,
         choices = "Generating..."
       ),
-        actionButton("btn_folder", "Go",
+        actionButton("btn_folder", "Download template",
           class = "btn-primary-color"
-        )
+        ),
+      actionButton("btn_folder_have_template",
+                   "I already have a template or manifest",
+                   class = "btn-primary-color"
+      )
       )
     )
   ),

--- a/ui.R
+++ b/ui.R
@@ -17,7 +17,41 @@ ui <- shinydashboardPlus::dashboardPage(
       span(class = "logo-lg", "Data Curator"),
       span(class = "logo-mini", "DCA")
     ),
-    uiOutput("logo")
+    uiOutput("logo"),
+    leftUi = tagList(
+      dropdownBlock(
+        id = "header_selection_dropdown",
+        title = "Selection",
+        icon = icon("sliders"),
+        badgeStatus = "info",
+        fluidRow(
+          div(
+            id = "header_content_project",
+            selectInput(
+              inputId = "header_dropdown_project",
+              label = NULL,
+              choices = "No project selected"
+            )
+          ),
+          div(
+            id = "header_content_template",
+            selectInput(
+              inputId = "header_dropdown_template",
+              label = NULL,
+              choices = "No template selected"
+            )
+          ),
+          div(
+            id = "header_content_folder",
+            selectInput(
+              inputId = "header_dropdown_folder",
+              label = NULL,
+              choices = "No folder selected"
+            )
+          )
+        )
+      )
+    )
   ),
   dashboardSidebar(
     width = 250,


### PR DESCRIPTION
Various UI updates to DCA

- Skip DCC selection screen if user has access to only one.
- Option to skip downloading a manifest and go straight to validation.
- Banner displaying users' selections.

Also, add support to configure schematic `manifest/generate --use-annotations` with dcc_config.csv