### PR TITLE
Wrap synapse_get_project in try() to better handle instances where no…

### DIFF
--- a/server.R
+++ b/server.R
@@ -248,16 +248,17 @@ shinyServer(function(input, output, session) {
       
       .asset_view <- selected$master_asset_view()
       promises::future_promise({
-      scopes <- synapse_get_project_scope(id = .asset_view, auth = access_token)
-      scope_access <- vapply(scopes, function(x) {
-      synapse_access(id=x, access="DOWNLOAD", auth=access_token)
-      }, 1L)
-      scopes <- scopes[scope_access==1]
-      projects <- bind_rows(
-      lapply(scopes, function(x) synapse_get(id=x, auth=access_token))
-      ) %>% arrange(name)
-      setNames(projects$id, projects$name)
-      
+        try({
+          scopes <- synapse_get_project_scope(id = .asset_view, auth = access_token)
+          scope_access <- vapply(scopes, function(x) {
+            synapse_access(id=x, access="DOWNLOAD", auth=access_token)
+          }, 1L)
+          scopes <- scopes[scope_access==1]
+          projects <- bind_rows(
+            lapply(scopes, function(x) synapse_get(id=x, auth=access_token))
+          ) %>% arrange(name)
+          setNames(projects$id, projects$name)
+        }, silent = FALSE)
       }) %...>% data_list$projects()
     
     } else {
@@ -273,7 +274,8 @@ shinyServer(function(input, output, session) {
   })
   
   observeEvent(data_list$projects(), ignoreInit = TRUE, {
-    if (is.null(data_list$projects()) || length(data_list$projects()) == 0) {
+    if (is.null(data_list$projects()) || length(data_list$projects()) == 0 ||
+        inherits(data_list$projects(), "try-error")) {
       dcWaiter("update", landing = TRUE, isPermission = FALSE)
     } else {
     
@@ -285,7 +287,6 @@ shinyServer(function(input, output, session) {
       )
       })
       })
-    }
     
     updateTabsetPanel(session, "tabs", selected = "tab_project")
     
@@ -296,6 +297,7 @@ shinyServer(function(input, output, session) {
     shinyjs::hide(select = "li:nth-child(6)")
     
     dcWaiter("hide")
+    }
   })
   
   observeEvent(input$dropdown_asset_view, {


### PR DESCRIPTION
Fixes https://sagebionetworks.jira.com/browse/FDS-775

Wrap the call to `synapse_get_projects()` in `try()` to avoid crashing the app. If no projects are retrieved, update the waiter screen to display a fileview or project permission error.