### PR TITLE
Increase titleMaxLength of info box

### DIFF
--- a/ui.R
+++ b/ui.R
@@ -123,7 +123,8 @@ ui <- shinydashboardPlus::dashboardPage(
   ),
   uiOutput("sass"),
   # load dependencies
-  use_notiflix_report(width = "500px", messageMaxLength = 10000),
+  use_notiflix_report(width = "500px", messageMaxLength = 10000,
+                      titleMaxLength = 100),
   use_waiter(),
   tabItems(
   # second tab content


### PR DESCRIPTION
The info box uses `shinypop::use_notiflix_report` which by default allows the title to be 34 characters. Set this to 100 to avoid an error.