### PR TITLE
Update base image to shiny-base release-1.9 which reduces superfluous…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/afwillia/shiny-base:release-1.8
+FROM ghcr.io/afwillia/shiny-base:release-1.9
 
 # add version tag as a build argument
 ARG DCA_VERSION


### PR DESCRIPTION
… log output

Change shiny server log level from `TRACE` to `INFO`. Most of the `TRACE` and `DEBUG` output is not helpful and bloats the logs.