### PR TITLE
Fds 1275 data model labels config

### DIFF
--- a/R/template_config.R
+++ b/R/template_config.R
@@ -22,9 +22,14 @@ get_display_names <- function(qlist) {
 }
 
 #' @export
-create_template_config <- function(data_model, include_schemas = NULL, exclude_schemas = NULL) {
+create_template_config <- function(
+  data_model,
+  include_schemas = NULL,
+  exclude_schemas = NULL,
+  data_model_labels = "class_label") {
+
   if (!is.null(include_schemas) && !is.null(exclude_schemas)) stop("include_schemas and exclude_schemas cannot both have values")
-  edges <- graph_by_edge_type(schema_url = data_model)
+  edges <- graph_by_edge_type(schema_url = data_model, data_model_labels = data_model_labels)
   schema_names <- format_edge_type(edges)
   nl <- setNames(as.list(schema_names$schema_name), rep("node_list", length(schema_names$schema_name)))
   dnames <- get_display_names(c(schema_url = data_model, nl)) |> httr::content()
@@ -44,8 +49,13 @@ create_template_config <- function(data_model, include_schemas = NULL, exclude_s
 }
 
 #' @export
-create_dca_template_config <- function(data_model, include_schemas = NULL, exclude_schemas = NULL) {
-  df <- create_template_config(data_model, include_schemas, exclude_schemas)
+create_dca_template_config <- function(
+  data_model,
+  include_schemas = NULL,
+  exclude_schemas = NULL,
+  data_model_labels = "class_label") {
+
+  df <- create_template_config(data_model, include_schemas, exclude_schemas, data_model_labels)
   schematic_version <- httr::GET("https://schematic-dev.api.sagebionetworks.org/v1/version") |>
     httr::content()
   list(
@@ -57,7 +67,13 @@ create_dca_template_config <- function(data_model, include_schemas = NULL, exclu
 
 #' @export
 #' @description Create a DCA-specific template generation function
-write_dca_template_config <- function(data_model, file, include_schemas = NULL, exclude_schemas = NULL) {
-  df <- create_dca_template_config(data_model, include_schemas, exclude_schemas)
+write_dca_template_config <- function(
+  data_model,
+  file,
+  include_schemas = NULL,
+  exclude_schemas = NULL,
+  data_model_labels = "class_label") {
+
+  df <- create_dca_template_config(data_model, include_schemas, exclude_schemas, data_model_labels)
   jsonlite::write_json(df, file, pretty = TRUE, auto_unbox = TRUE)
 }

--- a/R/template_config.R
+++ b/R/template_config.R
@@ -32,7 +32,12 @@ create_template_config <- function(
   edges <- graph_by_edge_type(schema_url = data_model, data_model_labels = data_model_labels)
   schema_names <- format_edge_type(edges)
   nl <- setNames(as.list(schema_names$schema_name), rep("node_list", length(schema_names$schema_name)))
-  dnames <- get_display_names(c(schema_url = data_model, nl)) |> httr::content()
+  dnames <- get_display_names(
+    c(schema_url = data_model,
+      nl,
+      data_model_labels=data_model_labels)
+    ) |> 
+    httr::content()
   config <- data.frame(display_name = unlist(dnames), schema_name = unlist(nl)) |>
     dplyr::left_join(schema_names, by = "schema_name") |>
     dplyr::mutate(type = ifelse(file_based, "file", "record")) |>


### PR DESCRIPTION
Add `data_model_labels` option to the functions that create [dca_template_config.json](https://github.com/Sage-Bionetworks/data_curator_config/blob/prod/demo/dca-template-config.json). These are used by a [github action to create the config file](https://github.com/Sage-Bionetworks/dca-template-config-action) in a [data model repo's workflows](https://github.com/Sage-Bionetworks/data-models/blob/main/.github/workflows/create-template-config.yml).