### PR TITLE
check config for enabling schematic validate cross manifest validatio…

### DIFF
--- a/server.R
+++ b/server.R
@@ -806,7 +806,10 @@ shinyServer(function(input, output, session) {
     # asset view must be NULL to avoid cross-manifest validation.
     # doing this in a verbose way to avoid warning with ifelse
     .asset_view <- NULL
-    if (!is.null(.project_scope)) .asset_view <- selected$master_asset_view()
+    if (!is.null(dcc_config_react()$schematic$model_validate$enable_cross_manifest_validation) &
+        isTRUE(dcc_config_react()$schematic$model_validate$enable_cross_manifest_validation)) {
+      .asset_view <- selected$master_asset_view()
+    }
 
     promises::future_promise({
       annotation_status <- switch(dca_schematic_api,
@@ -822,7 +825,7 @@ shinyServer(function(input, output, session) {
           data_type = .schema,
           file_name = .datapath,
           restrict_rules = .restrict_rules,
-          project_scope = .project_scope,
+          #project_scope = .project_scope,
           access_token = .access_token,
           data_model_labels = .data_model_labels,
           asset_view = .asset_view


### PR DESCRIPTION
…n. Remove project scope from validation query

- Super simple, just check for the `enable_cross_manifest_validation` value in the config. Then comment out `project_scope` in the `manifest/validate` query to use the default scope.

see https://github.com/Sage-Bionetworks/data_curator_config/pull/179 for the config changes.