### PR TITLE
Add folder to the synapse_entity_children request that checks for dat…

### DIFF
--- a/server.R
+++ b/server.R
@@ -480,7 +480,7 @@ shinyServer(function(input, output, session) {
       if (dca_synapse_api == TRUE & dca_schematic_api != "offline") {
         .folder <- selected$folder()
         promises::future_promise({
-          files <- synapse_entity_children(auth = access_token, parentId = .folder, includeTypes = list("file"))
+          files <- synapse_entity_children(auth = access_token, parentId = .folder, includeTypes = list("file", "folder"))
           if (nrow(files) > 0) {
             files_vec <- setNames(files$id, files$name)
           } else {


### PR DESCRIPTION
…a in folders.

Fix a false warning about  data not being in a folder, when folders are present.