### PR TITLE
More robustly check if a user is certified

### DIFF
--- a/R/synapse_rest_api.R
+++ b/R/synapse_rest_api.R
@@ -38,7 +38,8 @@ synapse_is_certified <- function(url="https://repo-prod.prod.sagebase.org/repo/v
   ownerid <- user_profile[["ownerId"]]
   url_req <- file.path(url, ownerid, endpoint)
   req <- httr::GET(url_req)
-  httr::content(req)[["passed"]]
+  resp <- httr::content(req)
+  resp[["certified"]]
   
 }
 

--- a/R/synapse_rest_api.R
+++ b/R/synapse_rest_api.R
@@ -39,7 +39,9 @@ synapse_is_certified <- function(url="https://repo-prod.prod.sagebase.org/repo/v
   url_req <- file.path(url, ownerid, endpoint)
   req <- httr::GET(url_req)
   resp <- httr::content(req)
-  resp[["certified"]]
+  if ("certified" %in% names(resp)) {
+    return(resp[["certified"]])
+  } else return(FALSE)
   
 }
 

--- a/functions/synapse_rest_api.R
+++ b/functions/synapse_rest_api.R
@@ -38,7 +38,8 @@ synapse_is_certified <- function(url="https://repo-prod.prod.sagebase.org/repo/v
   ownerid <- user_profile[["ownerId"]]
   url_req <- file.path(url, ownerid, endpoint)
   req <- httr::GET(url_req)
-  httr::content(req)[["passed"]]
+  resp <- httr::content(req)
+  resp[["certified"]]
   
 }
 

--- a/functions/synapse_rest_api.R
+++ b/functions/synapse_rest_api.R
@@ -39,7 +39,9 @@ synapse_is_certified <- function(url="https://repo-prod.prod.sagebase.org/repo/v
   url_req <- file.path(url, ownerid, endpoint)
   req <- httr::GET(url_req)
   resp <- httr::content(req)
-  resp[["certified"]]
+  if ("certified" %in% names(resp)) {
+    return(resp[["certified"]])
+  } else return(FALSE)
   
 }
 


### PR DESCRIPTION
Fixes a bug that crashes the app when loading the asset view selection screen for users that have not taken the certification quiz. For these users, the [synapse API endpoint certifiedUserPassingRecord](https://rest-docs.synapse.org/rest/GET/user/id/certifiedUserPassingRecord.html) returns a different structure than the code assumed. It assumed the endpoint always returned a [PassingRecord object](https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/quiz/PassingRecord.html) which contains the attribute "passed", but this is only returned for users who have attempted the certification quiz.

The code is now updated to check for the "certified" attribute in the response and return TRUE if it is TRUE. In all other instances it will return FALSE