### PR TITLE
try reconnect false

### DIFF
--- a/shiny-server.conf
+++ b/shiny-server.conf
@@ -25,6 +25,9 @@ server {
     # When a user visits the base URL rather than a particular application,
     # an index of the applications available in this directory will NOT be shown.
     directory_index off;
+
+    # Don't automatically reap user's session upon disconnect
+    reconnect false;
     
   }
 }


### PR DESCRIPTION
The shiny server docs https://docs.posit.co/shiny-server/#reconnect suggest that the default reconnect of true will immediately reap user's sessions upon disconnect. Setting to false may give users 15 seconds to refresh/reconnect their session.