### PR TITLE
Use shiny-base:release-1.11 which reverts back to ubuntu 22 instead o…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/afwillia/shiny-base:release-1.10
+FROM ghcr.io/afwillia/shiny-base:release-1.11
 
 # add version tag as a build argument
 ARG DCA_VERSION
@@ -7,7 +7,7 @@ ENV DCA_VERSION=$DCA_VERSION
 
 USER root
 RUN apt-get update
-RUN apt-get install -y libxml2 libglpk-dev libicu-dev libicu74 curl
+RUN apt-get install -y libxml2 libglpk-dev libicu-dev libicu70 curl
 
 # overwrite the default config with our modified copy
 COPY shiny-server.conf /etc/shiny-server/shiny-server.conf


### PR DESCRIPTION
…f 24. Also, restore libicu70 install instead of libicu74. All of this will resolve an issue installing stringi, which can be addressed with a planned upgrade in dependencies.

@lakikowolfe tagging you again to skip review. This reverts the libicu70 change earlier in the Dockerfile. It also uses a different image of shiny-base with ubuntu 22 instead of 24, which is what caused the libicu issue earlier.