### PR TITLE
change shiny-base image to release-1.12 which uses ubuntu jammy 22 in…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/afwillia/shiny-base:release-1.11
+FROM ghcr.io/afwillia/shiny-base:release-1.12
 
 # add version tag as a build argument
 ARG DCA_VERSION


### PR DESCRIPTION
Use shiny-base release-1.12 which actually uses ubuntu 22 instead of 1.11 which was mistakenly set to 20. @lakikowolfe just fyi, skipping review again. Hopefully for the last time.