### PR TITLE
remove trivy scan from docker build

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -53,17 +53,3 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             DCA_VERSION=${{ env.DCA_VERSION }}
-
-      - name: Lowercase image name for trivy
-        id: string
-        uses: ASzc/change-string-case-action@v6
-        with:
-          string: ${{ env.IMAGE_PATH }}
-      
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: '${{ steps.string.outputs.lowercase }}:${{ steps.meta.outputs.version }}'
-          format: 'table'
-          ignore-unfixed: true
-          severity: 'CRITICAL,HIGH'


### PR DESCRIPTION
trivy had a security incident, so remove it from the docker build workflow for now.