### PR TITLE
Add NF-OSI custom notice

### DIFF
--- a/server.R
+++ b/server.R
@@ -112,6 +112,7 @@ shinyServer(function(input, output, session) {
   shinyjs::hide("box_preview")
   shinyjs::hide("box_validate")
   shinyjs::hide("box_submit")
+  shinyjs::hide("box_nfosi_notice")
   
   # initial loading page
   observeEvent(input$cookie, {
@@ -151,9 +152,19 @@ shinyServer(function(input, output, session) {
       updateSelectInput(session, "dropdown_asset_view",
                         choices = asset_views()
       )
+
+      # Check if NF-OSI is selected and show notice
+      av_names <- names(asset_views())
+      if (length(av_names) > 0 && "NF-OSI" %in% av_names) {
+        # If NF-OSI is the first/only option, show the notice
+        if (av_names[1] == "NF-OSI") {
+          shinyjs::show("box_nfosi_notice")
+        }
+      }
     } else {
+      # In offline mode, still show all DCCs for testing purposes
       updateSelectInput(session, "dropdown_asset_view",
-        choices = c("Offline mock data (synXXXXXX)" = "synXXXXXX")
+        choices = all_asset_views
       )
       dcWaiter("hide")
     }
@@ -339,6 +350,15 @@ shinyServer(function(input, output, session) {
   observeEvent(input$dropdown_asset_view, {
     shinyjs::enable("btn_asset_view")
     shinyjs::enable("btn_template_select")
+
+    # Show NF-OSI deactivation notice if NF-OSI is selected
+    # Get the name corresponding to the selected asset view ID
+    selected_name <- names(all_asset_views[all_asset_views == input$dropdown_asset_view])
+    if (length(selected_name) > 0 && selected_name == "NF-OSI") {
+      shinyjs::show("box_nfosi_notice")
+    } else {
+      shinyjs::hide("box_nfosi_notice")
+    }
   })
 
   observeEvent(input$info_box, {

--- a/ui.R
+++ b/ui.R
@@ -127,6 +127,7 @@ ui <- shinydashboardPlus::dashboardPage(
   ),
   uiOutput("sass"),
   # load dependencies
+  useShinyjs(),
   use_notiflix_report(width = "500px", messageMaxLength = 10000,
                       titleMaxLength = 100),
   use_waiter(),
@@ -135,6 +136,23 @@ ui <- shinydashboardPlus::dashboardPage(
   tabItem(
     tabName = "tab_asset_view",
     fluidRow(
+      box(
+        id = "box_nfosi_notice",
+        status = "warning",
+        width = 12,
+        solidHeader = FALSE,
+        title = tagList(
+          icon("exclamation-triangle"),
+          "Important Notice"
+        ),
+        HTML(paste0(
+          "NF-OSI Data Curator will be retired on May 31, 2026. ",
+          "See the ",
+          "<a href='https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/synapse-curator-transition-guide' target='_blank'>",
+          "Synapse Curator Transition Guide</a> for how to use Synapse Curator already set up for your project, ",
+          "or contact <a href='mailto:nf-osi@sagebionetworks.org'>nf-osi@sagebionetworks.org</a> with questions."
+        ))
+      ),
       box(
         id = "box_pick_asset_view",
         status = "primary",
@@ -221,7 +239,6 @@ ui <- shinydashboardPlus::dashboardPage(
   ),
   tabItem(
     tabName = "tab_template",
-    useShinyjs(),
       fluidRow(
         box(
           title = textOutput('template_title'),


### PR DESCRIPTION
Hey @afwillia or @thomasyu888, we want to add NF-specific banner to give contributors a proper heads-up. Below shows changes in local testing. Tagging @BelindaBGarana as original suggestor + awareness for later updates if needed (hopefully we won't need to revise the notice, but you never know). 
<div>
    <a href="https://www.loom.com/share/a3de4a7bd678497381ae555914e38cb6">
      <p>Data Curator - 6 April 2026 - Loom</p>
    </a>
    <a href="https://www.loom.com/share/a3de4a7bd678497381ae555914e38cb6">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/a3de4a7bd678497381ae555914e38cb6-4c54efd4b4a718da-full-play.gif#t=0.1">
    </a>
  </div>